### PR TITLE
chore(workflow): initialize fiberplane tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ dist
 coverage
 .turbo
 storybook-static
+
+# Fiberplane local issue tracking
+.fp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+Never use raw WebSearch and WebFetch without first trying another tool, such as:
+- Exa via the Executor MCP
+- Parallel via the Executor MCP
+- Firecrawl via the Executor MCP
+- Perplexity via the Executor MCP
+- `nia` (for exploring GitHub repos)
+- `markit` (for reading URLs as Markdown)
+
+Code style for agents:
+- Decode external input once at the boundary, preferably with `effect/Schema`, then pass typed domain values inward.
+- Do not normalize arbitrary data in app logic with helpers like `asRecord`, `hasStringField`, loose `typeof` object checks, or ad hoc string-key probing.
+- Avoid `any`, `as`, `in`, `instanceof`, custom `is*` guards, and `try/catch` in normal application flow. If a boundary truly requires one of them, isolate it to that adapter and keep the rest of the system typed.
+- Prefer tagged unions, schema decoders, `Option`/`Either`, and Effect error channels over sentinel strings and defensive object spelunking.
+- Keep lint policy workspace-local: backend rules can be stricter and Effect-specific, while UI rules should focus on boundary safety and unsafe TypeScript escape hatches.
+
+@FP_AGENTS.md

--- a/FP_AGENTS.md
+++ b/FP_AGENTS.md
@@ -1,0 +1,53 @@
+<!-- DO NOT EDIT FP_AGENTS.md: This file is managed by fp. Run 'fp setup agent' to update. -->
+
+## FP Issue Tracking
+
+This project uses **fp** for issue tracking. AI agents must follow these rules.
+
+### Task Tracking
+
+- Use `fp issue` for all task tracking - do not use built-in todo tools
+- Create subissues with `--parent` flag - never use markdown checklists (`- [ ]`)
+- Break work into atomic tasks (1-3 hours each)
+
+### Work Session Flow
+
+1. `fp issue list --status todo` - find available work
+2. `fp issue update --status in-progress <id>` - claim it before starting
+3. Work and commit frequently
+4. `fp comment <id> "progress..."` - log at every milestone
+5. `fp issue assign <id> --rev <commit>` - attach commits to the issue
+6. `fp issue update --status done <id>` - mark complete when finished
+
+### Commit Discipline
+
+- Commit early and often with descriptive messages
+- Always commit before session ends
+- Always commit before context compaction
+
+### Progress Logging
+
+- Run `fp comment <id> "..."` at every milestone
+- Log after significant commits
+- Always leave a final comment before ending session
+
+### Commands Reference
+
+```bash
+fp tree [parent-id]        # View issue hierarchy (optionally only show tree of parent-id)
+fp issue list --status X   # Filter by status (todo/in-progress/done)
+fp issue create --title "..." --parent X --property key=value
+fp issue update --status X <id> --property key=value
+fp issue assign <id> --rev X  # Attach commit(s) to issue
+fp comment <id> "message"
+fp issue diff <id>         # See changes since task started
+fp context <id>            # Load full issue context
+fp extension docs          # Print the extensions authoring guide
+```
+
+### Extensions
+
+FP is extensible via TypeScript extensions. Extensions can hook into lifecycle events (e.g., after issue creation, before commits) to automate workflows.
+
+- Guide: `.fp/extensions/EXTENSIONS.md` (or run `fp extension docs` if the file is not present)
+- Extensions live in `.fp/extensions/` as `.ts` files


### PR DESCRIPTION
## Summary
- add repo-level agent instructions for working with Fiberplane-tracked tasks
- add a dedicated `FP_AGENTS.md` guide for issue creation, comments, and revision assignment
- ignore local Fiberplane workspace state so issue metadata stays out of the repo

## Verification
- reviewed the new workflow docs and gitignore updates locally
