### PR TITLE
chore(lint): restore effect file coverage

### DIFF
--- a/backend/.lintcn/linteffect/common.go
+++ b/backend/.lintcn/linteffect/common.go
@@ -24,18 +24,10 @@ func isEffectFile(ctx rule.RuleContext) bool {
 	if strings.Contains(fileName, "/vendor/") || strings.Contains(fileName, "/node_modules/") {
 		return false
 	}
-
-	excludedPaths := []string{
-		"/src/presentation/",
-		"/src/external/",
-		"/src/service/use-cases/",
-		"/src/service/CoffeeOrderApp.ts",
-		"/test/",
-	}
-	for _, excludedPath := range excludedPaths {
-		if strings.Contains(fileName, excludedPath) {
-			return false
-		}
+	if strings.Contains(fileName, "/test/") ||
+		strings.HasSuffix(fileName, ".test.ts") ||
+		strings.HasSuffix(fileName, ".spec.ts") {
+		return false
 	}
 
 	text := ctx.SourceFile.Text()

--- a/backend/.lintcn/linteffect/effect_file_gate_test.go
+++ b/backend/.lintcn/linteffect/effect_file_gate_test.go
@@ -1,0 +1,124 @@
+package linteffect
+
+import (
+	"testing"
+
+	"github.com/typescript-eslint/tsgolint/internal/rule_tester"
+)
+
+func TestNoIfStatementRuleCoversApplicationEffectFiles(t *testing.T) {
+	runLintEffectRuleTester(t, &NoIfStatementRule,
+		[]rule_tester.ValidTestCase{
+			{
+				FileName: "src/presentation/http/api.test.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("ignored test file");
+}
+        `,
+			},
+			{
+				FileName: "test/contracts/repository-contract.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("ignored test directory");
+}
+        `,
+			},
+			{
+				FileName: "src/vendor/generated.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("ignored vendor file");
+}
+        `,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				FileName: "src/presentation/http/api.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("presentation code is linted");
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIfStatement"},
+				},
+			},
+			{
+				FileName: "src/external/sql/repository.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("external code is linted");
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIfStatement"},
+				},
+			},
+			{
+				FileName: "src/service/use-cases/placeOrder.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("use case code is linted");
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIfStatement"},
+				},
+			},
+			{
+				FileName: "src/service/CoffeeOrderApp.ts",
+				Code: `
+"effect";
+declare const ready: boolean;
+if (ready) {
+  console.log("service app code is linted");
+}
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noIfStatement"},
+				},
+			},
+		},
+	)
+}
+
+func TestNoManualEffectChannelsRuleCoversApplicationEffectFiles(t *testing.T) {
+	runLintEffectRuleTester(t, &NoManualEffectChannelsRule,
+		[]rule_tester.ValidTestCase{
+			{
+				FileName: "src/presentation/http/api.test.ts",
+				Code: `
+"effect";
+type Ignored = Effect.Effect<string>;
+        `,
+			},
+		},
+		[]rule_tester.InvalidTestCase{
+			{
+				FileName: "src/presentation/assistant/handler.ts",
+				Code: `
+"effect";
+type CoffeeAppRunner = <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) => Promise<A>;
+        `,
+				Errors: []rule_tester.InvalidTestCaseError{
+					{MessageId: "noManualEffectChannels"},
+				},
+			},
+		},
+	)
+}

--- a/backend/.lintcn/linteffect/no_string_sentinel_const.go
+++ b/backend/.lintcn/linteffect/no_string_sentinel_const.go
@@ -5,9 +5,34 @@
 package linteffect
 
 import (
+	"strings"
+
 	"github.com/microsoft/typescript-go/shim/ast"
 	"github.com/typescript-eslint/tsgolint/internal/rule"
 )
+
+var stringSentinelConstNeedles = []string{
+	"status",
+	"state",
+	"phase",
+	"mode",
+	"kind",
+	"tag",
+}
+
+func isStringSentinelConstName(node *ast.Node) bool {
+	name := nodeText(node)
+	if name == "" {
+		return false
+	}
+	lower := strings.ToLower(name)
+	for _, needle := range stringSentinelConstNeedles {
+		if strings.Contains(lower, needle) {
+			return true
+		}
+	}
+	return false
+}
 
 var NoStringSentinelConstRule = rule.Rule{
 	Name: "no-string-sentinel-const",
@@ -21,7 +46,9 @@ var NoStringSentinelConstRule = rule.Rule{
 					return
 				}
 				init := node.AsVariableDeclaration().Initializer
-				if init != nil && init.Kind == ast.KindStringLiteral {
+				if init != nil &&
+					init.Kind == ast.KindStringLiteral &&
+					isStringSentinelConstName(node.AsVariableDeclaration().Name()) {
 					reportRule(ctx, node, "noStringSentinelConst", "Rule: avoid string status constants. Why: they encode control flow and force defensive branching. Fix: use tagged unions, Option/Either, or meaningful domain values instead of string tokens.")
 				}
 			},

--- a/backend/.lintcn/linteffect/ported_rules_coverage_test.go
+++ b/backend/.lintcn/linteffect/ported_rules_coverage_test.go
@@ -320,6 +320,10 @@ const load = Effect.succeed("loading");
 "effect";
 const status = { kind: "loading" };
         `),
+				validCase(`
+"effect";
+const syntheticEmailDomain = "users.onion.invalid";
+        `),
 			},
 			invalid: []rule_tester.InvalidTestCase{
 				invalidRuleCase(`


### PR DESCRIPTION
## Summary
- stop silently excluding backend presentation/external/use-case/CoffeeOrderApp files from Effect-specific lint rules
- keep vendor, node_modules, and test files excluded to avoid fixture noise
- refine no-string-sentinel-const so it only flags control-flow-like sentinel names instead of arbitrary config strings
- add rule tests that lock the new file-gate behavior

## Verification
- bun run --cwd backend lint:custom
- bun run --cwd backend check
- bun run check