### PR TITLE
refactor(cloudflare): add effect config boundary

### DIFF
--- a/backend/src/presentation/README.md
+++ b/backend/src/presentation/README.md
@@ -146,7 +146,7 @@ That file is a good example of accidental complexity:
 - [router.ts](./cloudflare/router.ts): Assembly-only route ordering for Cloudflare mounts.
 - [host.ts](./cloudflare/host.ts): Generic Worker host that handles ordered mount dispatch plus request-level logging/error logging.
 - [mount.ts](./cloudflare/mount.ts): Small Cloudflare mount and request-context primitives shared across presentation surfaces.
-- [context.ts](./cloudflare/context.ts): Typed Cloudflare env/binding surface used by the Worker entrypoint and feature mounts.
+- [context.ts](./cloudflare/context.ts): Typed Cloudflare env/binding surface plus a small Effect-native config boundary that normalizes optional string settings and object bindings before mounts consume them.
 - [assets-mount.ts](./cloudflare/assets-mount.ts): Static asset fallback mount for non-API requests.
 
 ### `observability/`

--- a/backend/src/presentation/assistant/cloudflare-mount.ts
+++ b/backend/src/presentation/assistant/cloudflare-mount.ts
@@ -1,6 +1,11 @@
+import * as Option from "effect/Option";
 import { getAssistantModel, handleAssistantRequest } from "#presentation/assistant/handler";
 import type { AssistantAiConfig } from "#presentation/assistant/runtime";
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import {
+  readCloudflareRuntime,
+  type CloudflareRuntime,
+  type CloudflareWorkerEnv,
+} from "#presentation/cloudflare/context";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -22,41 +27,42 @@ const rewriteApiRequest = (request: Request): Request => {
   return rewriteRequestPath(request, rewrittenPathname);
 };
 
-const getAssistantAiConfig = (env: OnionCloudflareWorkerEnv): AssistantAiConfig | undefined => {
-  const binding = env.AI;
-
-  if (binding === undefined) {
+const getAssistantAiConfig = (runtime: CloudflareRuntime): AssistantAiConfig | undefined => {
+  if (Option.isNone(runtime.bindings.ai)) {
     return undefined;
   }
 
-  const gatewayId = env.AI_GATEWAY_ID?.trim();
+  const binding = runtime.bindings.ai.value;
 
-  return gatewayId === undefined || gatewayId === ""
-    ? { binding, kind: "binding" }
-    : { binding, gatewayId, kind: "binding" };
+  return Option.match(runtime.config.aiGatewayId, {
+    onNone: () => ({ binding, kind: "binding" }),
+    onSome: (gatewayId) => ({ binding, gatewayId, kind: "binding" }),
+  });
 };
 
-export const cloudflareAssistantMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareAssistantMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "assistant",
   matches: isAssistantRequest,
   handle: async ({ env, request }) => {
+    const runtime = readCloudflareRuntime(env);
+
     await ensureCloudflareAuthPersistence({
-      db: env.DB,
-      secret: env.BETTER_AUTH_SECRET,
+      db: runtime.bindings.db,
+      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
     });
 
     const actor = await resolveCloudflareActor({
-      db: env.DB,
+      db: runtime.bindings.db,
       request,
-      secret: env.BETTER_AUTH_SECRET,
-      staffUserIds: env.COFFEE_STAFF_USER_IDS,
+      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+      staffUserIds: runtime.config.staffUserIds,
     });
 
     return cloudflareResponse(
       await handleAssistantRequest(rewriteApiRequest(request), {
         actor,
-        ai: getAssistantAiConfig(env),
-        appLayer: makeCloudflareCoffeeAppLive(env.DB),
+        ai: getAssistantAiConfig(runtime),
+        appLayer: makeCloudflareCoffeeAppLive(runtime.bindings.db),
         model: getAssistantModel(),
       }),
       actorLogFields(actor),

--- a/backend/src/presentation/auth/cloudflare-mount.ts
+++ b/backend/src/presentation/auth/cloudflare-mount.ts
@@ -1,4 +1,5 @@
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import * as Option from "effect/Option";
+import { readCloudflareRuntime, type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -10,8 +11,6 @@ import { createCloudflareAuth, ensureCloudflareAuthPersistence } from "#presenta
 const betterAuthUnavailableResponse = () =>
   new Response("Better Auth is unavailable. Configure BETTER_AUTH_SECRET.", { status: 503 });
 
-const hasBetterAuthSecret = (secret: string | undefined) => (secret?.trim() ?? "") !== "";
-
 const isAgentDiscoveryRequest = (request: Request): boolean =>
   cloudflarePathname(request) === "/.well-known/agent-configuration";
 
@@ -20,30 +19,32 @@ const isAuthRequest = (request: Request): boolean => {
   return pathname === "/api/auth" || pathname.startsWith("/api/auth/");
 };
 
-const ensureAuthPersistence = async (env: OnionCloudflareWorkerEnv): Promise<void> =>
-  ensureCloudflareAuthPersistence({
-    db: env.DB,
-    secret: env.BETTER_AUTH_SECRET,
-  });
+const ensureAuthPersistence = async (env: CloudflareWorkerEnv): Promise<void> => {
+  const runtime = readCloudflareRuntime(env);
 
-const handleAuthRequest = async (
-  request: Request,
-  env: OnionCloudflareWorkerEnv,
-): Promise<Response> => {
-  if (!hasBetterAuthSecret(env.BETTER_AUTH_SECRET)) {
+  return ensureCloudflareAuthPersistence({
+    db: runtime.bindings.db,
+    secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+  });
+};
+
+const handleAuthRequest = async (request: Request, env: CloudflareWorkerEnv): Promise<Response> => {
+  const runtime = readCloudflareRuntime(env);
+
+  if (Option.isNone(runtime.config.betterAuthSecret)) {
     return betterAuthUnavailableResponse();
   }
 
   await ensureAuthPersistence(env);
 
   return createCloudflareAuth({
-    db: env.DB,
+    db: runtime.bindings.db,
     request,
-    secret: env.BETTER_AUTH_SECRET,
+    secret: runtime.config.betterAuthSecret.value,
   }).handler(request);
 };
 
-export const cloudflareAgentDiscoveryMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareAgentDiscoveryMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "agent-discovery",
   matches: isAgentDiscoveryRequest,
   handle: async ({ env, request }) =>
@@ -52,7 +53,7 @@ export const cloudflareAgentDiscoveryMount: CloudflareMount<OnionCloudflareWorke
     ),
 };
 
-export const cloudflareAuthMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareAuthMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "auth",
   matches: isAuthRequest,
   handle: async ({ env, request }) => cloudflareResponse(await handleAuthRequest(request, env)),

--- a/backend/src/presentation/auth/server.ts
+++ b/backend/src/presentation/auth/server.ts
@@ -126,15 +126,6 @@ function buildAuthOptions(input: {
   };
 }
 
-function parseStaffUserIds(value: string | undefined): Set<string> {
-  return new Set(
-    (value ?? "")
-      .split(",")
-      .map((entry) => entry.trim())
-      .filter((entry) => entry.length > 0),
-  );
-}
-
 async function ensureOrderOwnershipColumn(db: D1Database): Promise<void> {
   const table = await db
     .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'orders'")
@@ -207,7 +198,7 @@ export async function resolveCloudflareActor(input: {
   readonly db: D1Database;
   readonly request: Request;
   readonly secret: string | undefined;
-  readonly staffUserIds: string | undefined;
+  readonly staffUserIds: ReadonlySet<string>;
 }): Promise<AppActor> {
   if ((input.secret?.trim() ?? "") === "") {
     return anonymousActor;
@@ -222,11 +213,9 @@ export async function resolveCloudflareActor(input: {
     return anonymousActor;
   }
 
-  const staffUserIds = parseStaffUserIds(input.staffUserIds);
-
   return decodeResolvedActor({
     displayName: session.user.name.trim() || session.user.email,
-    kind: staffUserIds.has(session.user.id) ? "staff" : "customer",
+    kind: input.staffUserIds.has(session.user.id) ? "staff" : "customer",
     userId: session.user.id,
   });
 }

--- a/backend/src/presentation/cloudflare/assets-mount.ts
+++ b/backend/src/presentation/cloudflare/assets-mount.ts
@@ -1,13 +1,20 @@
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import * as Option from "effect/Option";
+import { readCloudflareRuntime, type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 import { cloudflareResponse, type CloudflareMount } from "#presentation/cloudflare/mount";
 
 const notFoundResponse = () => new Response("Not Found", { status: 404 });
 
-export const cloudflareAssetsMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareAssetsMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "assets",
   matches: () => true,
-  handle: async ({ env, request }) =>
-    cloudflareResponse(
-      env.ASSETS === undefined ? notFoundResponse() : await env.ASSETS.fetch(request),
-    ),
+  handle: async ({ env, request }) => {
+    const runtime = readCloudflareRuntime(env);
+
+    return cloudflareResponse(
+      await Option.match(runtime.bindings.assets, {
+        onNone: async () => notFoundResponse(),
+        onSome: async (assets) => assets.fetch(request),
+      }),
+    );
+  },
 };

--- a/backend/src/presentation/cloudflare/context.test.ts
+++ b/backend/src/presentation/cloudflare/context.test.ts
@@ -1,0 +1,77 @@
+import type {
+  AiTextGenerationInput,
+  AiTextGenerationOutput,
+  D1Database,
+} from "@cloudflare/workers-types";
+import * as Option from "effect/Option";
+import { Miniflare } from "miniflare";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  readCloudflareRuntime,
+  type AssetFetcher,
+  type CloudflareWorkerEnv,
+  type WorkersAiBinding,
+} from "./context.ts";
+
+const makeAiBinding = (): WorkersAiBinding => ({
+  run: async (_model: string, _inputs: AiTextGenerationInput): Promise<AiTextGenerationOutput> =>
+    Promise.reject("not used in this test"),
+});
+
+const makeAssetFetcher = (): AssetFetcher => ({
+  fetch: async () => new Response("ok"),
+});
+
+let database: D1Database;
+let disposeMiniflare: () => Promise<void>;
+
+describe("cloudflare runtime config", () => {
+  beforeAll(async () => {
+    const miniflare = new Miniflare({
+      d1Databases: {
+        DB: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+      },
+      modules: true,
+      script: "",
+    });
+
+    database = await miniflare.getD1Database("DB");
+    disposeMiniflare = async () => miniflare.dispose();
+  });
+
+  afterAll(async () => {
+    await disposeMiniflare();
+  });
+
+  it("normalizes optional strings and staff ids", () => {
+    const runtime = readCloudflareRuntime({
+      AI: makeAiBinding(),
+      AI_GATEWAY_ID: " gateway-123 ",
+      ASSETS: makeAssetFetcher(),
+      BETTER_AUTH_SECRET: " secret-123 ",
+      COFFEE_STAFF_USER_IDS: " staff-a, staff-b , , staff-a ",
+      DB: database,
+    });
+
+    expect(Option.isSome(runtime.bindings.ai)).toBe(true);
+    expect(Option.isSome(runtime.bindings.assets)).toBe(true);
+    expect(Option.getOrUndefined(runtime.config.aiGatewayId)).toBe("gateway-123");
+    expect(Option.getOrUndefined(runtime.config.betterAuthSecret)).toBe("secret-123");
+    expect([...runtime.config.staffUserIds]).toEqual(["staff-a", "staff-b"]);
+  });
+
+  it("treats missing or blank optional values as absent", () => {
+    const runtime = readCloudflareRuntime({
+      AI_GATEWAY_ID: "   ",
+      BETTER_AUTH_SECRET: "",
+      COFFEE_STAFF_USER_IDS: " ,  , ",
+      DB: database,
+    } satisfies CloudflareWorkerEnv);
+
+    expect(Option.isNone(runtime.bindings.ai)).toBe(true);
+    expect(Option.isNone(runtime.bindings.assets)).toBe(true);
+    expect(Option.isNone(runtime.config.aiGatewayId)).toBe(true);
+    expect(Option.isNone(runtime.config.betterAuthSecret)).toBe(true);
+    expect([...runtime.config.staffUserIds]).toEqual([]);
+  });
+});

--- a/backend/src/presentation/cloudflare/context.ts
+++ b/backend/src/presentation/cloudflare/context.ts
@@ -3,6 +3,11 @@ import type {
   AiTextGenerationOutput,
   D1Database,
 } from "@cloudflare/workers-types";
+import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
 
 export type AssetFetcher = { fetch(request: Request): Promise<Response> };
 
@@ -14,7 +19,7 @@ export interface WorkersAiBinding {
   ): Promise<AiTextGenerationOutput>;
 }
 
-export interface OnionCloudflareWorkerEnv {
+export interface CloudflareWorkerEnv {
   AI?: WorkersAiBinding;
   AI_GATEWAY_ID?: string;
   BETTER_AUTH_SECRET?: string;
@@ -22,3 +27,56 @@ export interface OnionCloudflareWorkerEnv {
   DB: D1Database;
   ASSETS?: AssetFetcher;
 }
+
+export interface CloudflareRuntime {
+  readonly bindings: {
+    readonly ai: Option.Option<WorkersAiBinding>;
+    readonly assets: Option.Option<AssetFetcher>;
+    readonly db: D1Database;
+  };
+  readonly config: {
+    readonly aiGatewayId: Option.Option<string>;
+    readonly betterAuthSecret: Option.Option<string>;
+    readonly staffUserIds: ReadonlySet<string>;
+  };
+}
+
+const cloudflareConfig = Config.all({
+  aiGatewayId: Config.string("aiGatewayId").pipe(Config.withDefault("")),
+  betterAuthSecret: Config.string("betterAuthSecret").pipe(Config.withDefault("")),
+  coffeeStaffUserIds: Config.string("coffeeStaffUserIds").pipe(Config.withDefault("")),
+});
+
+const decodeTrimmedString = (value: string): string => Schema.decodeUnknownSync(Schema.Trim)(value);
+
+const optionalTrimmedString = (value: string): Option.Option<string> => {
+  const trimmed = decodeTrimmedString(value);
+  return trimmed === "" ? Option.none() : Option.some(trimmed);
+};
+
+const parseStaffUserIds = (value: string): ReadonlySet<string> =>
+  new Set(
+    value
+      .split(",")
+      .map(decodeTrimmedString)
+      .filter((entry) => entry !== ""),
+  );
+
+export const readCloudflareRuntime = (env: CloudflareWorkerEnv): CloudflareRuntime => {
+  const decodedConfig = Effect.runSync(
+    cloudflareConfig.parse(ConfigProvider.fromUnknown(env).pipe(ConfigProvider.constantCase)),
+  );
+
+  return {
+    bindings: {
+      ai: Option.fromNullishOr(env.AI),
+      assets: Option.fromNullishOr(env.ASSETS),
+      db: env.DB,
+    },
+    config: {
+      aiGatewayId: optionalTrimmedString(decodedConfig.aiGatewayId),
+      betterAuthSecret: optionalTrimmedString(decodedConfig.betterAuthSecret),
+      staffUserIds: parseStaffUserIds(decodedConfig.coffeeStaffUserIds),
+    },
+  };
+};

--- a/backend/src/presentation/cloudflare/router.ts
+++ b/backend/src/presentation/cloudflare/router.ts
@@ -4,13 +4,13 @@ import {
   cloudflareAgentDiscoveryMount,
   cloudflareAuthMount,
 } from "#presentation/auth/cloudflare-mount";
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import type { CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 import { cloudflareAssetsMount } from "#presentation/cloudflare/assets-mount";
 import { createCloudflareHost } from "#presentation/cloudflare/host";
 import { cloudflareHttpApiMount } from "#presentation/http/cloudflare-mount";
 import { cloudflareMcpMount } from "#presentation/mcp/cloudflare-mount";
 
-const routeRequest = createCloudflareHost<OnionCloudflareWorkerEnv>([
+const routeRequest = createCloudflareHost<CloudflareWorkerEnv>([
   cloudflareAgentDiscoveryMount,
   cloudflareAuthMount,
   cloudflareAssistantMount,
@@ -19,10 +19,10 @@ const routeRequest = createCloudflareHost<OnionCloudflareWorkerEnv>([
   cloudflareAssetsMount,
 ]);
 
-export { type OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+export { type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 
 export const routeCloudflareRequest = async (
   request: Request,
-  env: OnionCloudflareWorkerEnv,
+  env: CloudflareWorkerEnv,
   executionContext: ExecutionContext,
 ): Promise<Response> => routeRequest(request, env, executionContext);

--- a/backend/src/presentation/cloudflare/worker.ts
+++ b/backend/src/presentation/cloudflare/worker.ts
@@ -1,13 +1,10 @@
 import type { ExecutionContext } from "@cloudflare/workers-types";
-import {
-  routeCloudflareRequest,
-  type OnionCloudflareWorkerEnv,
-} from "#presentation/cloudflare/router";
+import { routeCloudflareRequest, type CloudflareWorkerEnv } from "#presentation/cloudflare/router";
 
-export type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/router";
+export type { CloudflareWorkerEnv } from "#presentation/cloudflare/router";
 
 export default {
-  async fetch(request: Request, env: OnionCloudflareWorkerEnv, executionContext: ExecutionContext) {
+  async fetch(request: Request, env: CloudflareWorkerEnv, executionContext: ExecutionContext) {
     return routeCloudflareRequest(request, env, executionContext);
   },
 };

--- a/backend/src/presentation/http/cloudflare-mount.ts
+++ b/backend/src/presentation/http/cloudflare-mount.ts
@@ -1,5 +1,6 @@
+import * as Option from "effect/Option";
 import { actorLogFields } from "#presentation/observability/logging";
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import { readCloudflareRuntime, type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -23,24 +24,26 @@ const rewriteApiRequest = (request: Request): Request => {
   return rewriteRequestPath(request, rewrittenPathname);
 };
 
-export const cloudflareHttpApiMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareHttpApiMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "api",
   matches: isApiRequest,
   handle: async ({ env, request }) => {
+    const runtime = readCloudflareRuntime(env);
+
     await ensureCloudflareAuthPersistence({
-      db: env.DB,
-      secret: env.BETTER_AUTH_SECRET,
+      db: runtime.bindings.db,
+      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
     });
 
     const actor = await resolveCloudflareActor({
-      db: env.DB,
+      db: runtime.bindings.db,
       request,
-      secret: env.BETTER_AUTH_SECRET,
-      staffUserIds: env.COFFEE_STAFF_USER_IDS,
+      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+      staffUserIds: runtime.config.staffUserIds,
     });
 
     return cloudflareResponse(
-      await getCloudflareBackendHandler(env.DB)(
+      await getCloudflareBackendHandler(runtime.bindings.db)(
         rewriteApiRequest(request),
         createCloudflareRequestServices(actor),
       ),

--- a/backend/src/presentation/mcp/cloudflare-mount.ts
+++ b/backend/src/presentation/mcp/cloudflare-mount.ts
@@ -1,4 +1,5 @@
-import type { OnionCloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import * as Option from "effect/Option";
+import { readCloudflareRuntime, type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -16,17 +17,19 @@ const isMcpRequest = (request: Request): boolean => {
   return pathname === "/mcp" || pathname.startsWith("/mcp/");
 };
 
-export const cloudflareMcpMount: CloudflareMount<OnionCloudflareWorkerEnv> = {
+export const cloudflareMcpMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "mcp",
   matches: isMcpRequest,
   handle: async ({ env, request }) => {
+    const runtime = readCloudflareRuntime(env);
+
     await ensureCloudflareAuthPersistence({
-      db: env.DB,
-      secret: env.BETTER_AUTH_SECRET,
+      db: runtime.bindings.db,
+      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
     });
 
     return cloudflareResponse(
-      await getCloudflareBackendHandler(env.DB)(
+      await getCloudflareBackendHandler(runtime.bindings.db)(
         request,
         createCloudflareRequestServices(systemActor),
       ),

--- a/backend/test/presentation/cloudflare/worker.test.ts
+++ b/backend/test/presentation/cloudflare/worker.test.ts
@@ -1,14 +1,12 @@
 import type { D1Database, ExecutionContext } from "@cloudflare/workers-types";
 import { Miniflare } from "miniflare";
 import { describe, expect, it, vi } from "vitest";
-import worker, {
-  type OnionCloudflareWorkerEnv,
-} from "../../../src/presentation/cloudflare/worker.ts";
+import worker, { type CloudflareWorkerEnv } from "../../../src/presentation/cloudflare/worker.ts";
 
 const makeTestEnv = async (): Promise<{
   assetsFetch: ReturnType<typeof vi.fn<(request: Request) => Promise<Response>>>;
   dispose: () => Promise<void>;
-  env: OnionCloudflareWorkerEnv;
+  env: CloudflareWorkerEnv;
 }> => {
   const miniflare = new Miniflare({
     d1Databases: {


### PR DESCRIPTION
## Summary
- add a typed Cloudflare runtime reader that uses Effect ConfigProvider and Schema trimming for optional string settings
- normalize Worker bindings and config once before the Cloudflare mounts consume them
- cover the new boundary with a focused runtime config test and update the presentation README

## Verification
- bun run check