### PR TITLE
refactor(auth): keep agent bearer tokens off direct HTTP routes

### DIFF
--- a/backend/src/presentation/README.md
+++ b/backend/src/presentation/README.md
@@ -112,6 +112,7 @@ Why this exists:
 - passkey auth, session cookies, and staff/customer actor resolution are presentation-boundary concerns
 - Agent Auth adds another public protocol surface with discovery, approval, and capability execution
 - Better Auth needs Cloudflare-specific setup and persistence bootstrapping that should not leak into the domain or service layers
+- Direct HTTP routes stay session-cookie-based; delegated agent access stays behind MCP and Better Auth capability execution rather than broad bearer-token access across `/api/*`
 
 ### `mcp/`
 

--- a/backend/src/presentation/assistant/cloudflare-mount.ts
+++ b/backend/src/presentation/assistant/cloudflare-mount.ts
@@ -6,6 +6,7 @@ import {
   type CloudflareRuntime,
   type CloudflareWorkerEnv,
 } from "#presentation/cloudflare/context";
+import { rejectDirectHttpBearerRequest } from "#presentation/cloudflare/direct-http-auth";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -27,45 +28,46 @@ const rewriteApiRequest = (request: Request): Request => {
   return rewriteRequestPath(request, rewrittenPathname);
 };
 
-const getAssistantAiConfig = (runtime: CloudflareRuntime): AssistantAiConfig | undefined => {
-  if (Option.isNone(runtime.bindings.ai)) {
-    return undefined;
-  }
-
-  const binding = runtime.bindings.ai.value;
-
-  return Option.match(runtime.config.aiGatewayId, {
-    onNone: () => ({ binding, kind: "binding" }),
-    onSome: (gatewayId) => ({ binding, gatewayId, kind: "binding" }),
+const getAssistantAiConfig = (runtime: CloudflareRuntime): AssistantAiConfig | undefined =>
+  Option.match(runtime.bindings.ai, {
+    onNone: () => undefined,
+    onSome: (binding) =>
+      Option.match(runtime.config.aiGatewayId, {
+        onNone: () => ({ binding, kind: "binding" }),
+        onSome: (gatewayId) => ({ binding, gatewayId, kind: "binding" }),
+      }),
   });
-};
 
 export const cloudflareAssistantMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "assistant",
   matches: isAssistantRequest,
-  handle: async ({ env, request }) => {
-    const runtime = readCloudflareRuntime(env);
+  handle: async ({ env, request }) =>
+    Option.match(Option.fromNullishOr(rejectDirectHttpBearerRequest(request)), {
+      onNone: async () => {
+        const runtime = readCloudflareRuntime(env);
 
-    await ensureCloudflareAuthPersistence({
-      db: runtime.bindings.db,
-      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
-    });
+        await ensureCloudflareAuthPersistence({
+          db: runtime.bindings.db,
+          secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+        });
 
-    const actor = await resolveCloudflareActor({
-      db: runtime.bindings.db,
-      request,
-      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
-      staffUserIds: runtime.config.staffUserIds,
-    });
+        const actor = await resolveCloudflareActor({
+          db: runtime.bindings.db,
+          request,
+          secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+          staffUserIds: runtime.config.staffUserIds,
+        });
 
-    return cloudflareResponse(
-      await handleAssistantRequest(rewriteApiRequest(request), {
-        actor,
-        ai: getAssistantAiConfig(runtime),
-        appLayer: makeCloudflareCoffeeAppLive(runtime.bindings.db),
-        model: getAssistantModel(),
-      }),
-      actorLogFields(actor),
-    );
-  },
+        return cloudflareResponse(
+          await handleAssistantRequest(rewriteApiRequest(request), {
+            actor,
+            ai: getAssistantAiConfig(runtime),
+            appLayer: makeCloudflareCoffeeAppLive(runtime.bindings.db),
+            model: getAssistantModel(),
+          }),
+          actorLogFields(actor),
+        );
+      },
+      onSome: async (response: Response) => cloudflareResponse(response),
+    }),
 };

--- a/backend/src/presentation/cloudflare/direct-http-auth.ts
+++ b/backend/src/presentation/cloudflare/direct-http-auth.ts
@@ -1,0 +1,25 @@
+const hasBearerAuthorization = (request: Request): boolean => {
+  const authorization = request.headers.get("authorization");
+
+  if (authorization === null) {
+    return false;
+  }
+
+  return authorization.trimStart().toLowerCase().startsWith("bearer ");
+};
+
+export const rejectDirectHttpBearerRequest = (request: Request): Response | undefined => {
+  if (!hasBearerAuthorization(request)) {
+    return undefined;
+  }
+
+  return Response.json(
+    {
+      error:
+        "Direct HTTP routes do not accept bearer agent tokens. Use session cookies for the app UI/API or MCP capability execution for agent access.",
+    },
+    {
+      status: 400,
+    },
+  );
+};

--- a/backend/src/presentation/http/cloudflare-mount.ts
+++ b/backend/src/presentation/http/cloudflare-mount.ts
@@ -1,6 +1,7 @@
 import * as Option from "effect/Option";
 import { actorLogFields } from "#presentation/observability/logging";
 import { readCloudflareRuntime, type CloudflareWorkerEnv } from "#presentation/cloudflare/context";
+import { rejectDirectHttpBearerRequest } from "#presentation/cloudflare/direct-http-auth";
 import {
   cloudflarePathname,
   cloudflareResponse,
@@ -27,27 +28,31 @@ const rewriteApiRequest = (request: Request): Request => {
 export const cloudflareHttpApiMount: CloudflareMount<CloudflareWorkerEnv> = {
   name: "api",
   matches: isApiRequest,
-  handle: async ({ env, request }) => {
-    const runtime = readCloudflareRuntime(env);
+  handle: async ({ env, request }) =>
+    Option.match(Option.fromNullishOr(rejectDirectHttpBearerRequest(request)), {
+      onNone: async () => {
+        const runtime = readCloudflareRuntime(env);
 
-    await ensureCloudflareAuthPersistence({
-      db: runtime.bindings.db,
-      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
-    });
+        await ensureCloudflareAuthPersistence({
+          db: runtime.bindings.db,
+          secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+        });
 
-    const actor = await resolveCloudflareActor({
-      db: runtime.bindings.db,
-      request,
-      secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
-      staffUserIds: runtime.config.staffUserIds,
-    });
+        const actor = await resolveCloudflareActor({
+          db: runtime.bindings.db,
+          request,
+          secret: Option.getOrUndefined(runtime.config.betterAuthSecret),
+          staffUserIds: runtime.config.staffUserIds,
+        });
 
-    return cloudflareResponse(
-      await getCloudflareBackendHandler(runtime.bindings.db)(
-        rewriteApiRequest(request),
-        createCloudflareRequestServices(actor),
-      ),
-      actorLogFields(actor),
-    );
-  },
+        return cloudflareResponse(
+          await getCloudflareBackendHandler(runtime.bindings.db)(
+            rewriteApiRequest(request),
+            createCloudflareRequestServices(actor),
+          ),
+          actorLogFields(actor),
+        );
+      },
+      onSome: async (response: Response) => cloudflareResponse(response),
+    }),
 };

--- a/backend/test/presentation/cloudflare/worker.test.ts
+++ b/backend/test/presentation/cloudflare/worker.test.ts
@@ -64,6 +64,59 @@ describe("cloudflare worker", () => {
     }
   });
 
+  it("rejects bearer tokens on direct app API routes", async () => {
+    const { dispose, env } = await makeTestEnv();
+
+    try {
+      const response = await worker.fetch(
+        new Request("http://example.com/api/me", {
+          headers: {
+            authorization: "Bearer agent-token",
+          },
+        }),
+        env,
+        executionContext,
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          "Direct HTTP routes do not accept bearer agent tokens. Use session cookies for the app UI/API or MCP capability execution for agent access.",
+      });
+    } finally {
+      await dispose();
+    }
+  });
+
+  it("rejects bearer tokens on the assistant HTTP route", async () => {
+    const { dispose, env } = await makeTestEnv();
+
+    try {
+      const response = await worker.fetch(
+        new Request("http://example.com/api/assistant", {
+          body: JSON.stringify({
+            messages: [],
+          }),
+          headers: {
+            authorization: "Bearer agent-token",
+            "content-type": "application/json",
+          },
+          method: "POST",
+        }),
+        env,
+        executionContext,
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.json()).resolves.toEqual({
+        error:
+          "Direct HTTP routes do not accept bearer agent tokens. Use session cookies for the app UI/API or MCP capability execution for agent access.",
+      });
+    } finally {
+      await dispose();
+    }
+  });
+
   it("serves the MCP HTTP surface without rewriting the path", async () => {
     const { assetsFetch, dispose, env } = await makeTestEnv();
 


### PR DESCRIPTION
## Summary
- explicitly reject bearer agent tokens on non-MCP direct HTTP routes
- keep delegated agent access behind MCP and Better Auth capability execution
- add Cloudflare worker regression coverage for `/api/me` and `/api/assistant`

## Verification
- bun run check
