### PR TITLE
refactor(sql): build order filters from statement fragments

### DIFF
--- a/backend/src/external/sql/SqlOrderRepository.ts
+++ b/backend/src/external/sql/SqlOrderRepository.ts
@@ -1,3 +1,4 @@
+import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
@@ -34,38 +35,36 @@ const makeSqlOrderQueries = Effect.gen(function* () {
 
   const update = (order: typeof SqlOrderModel.update.Type) => repository.update(order);
 
+  const buildListWhereClauses = (filters: ListOrdersFilters) =>
+    Arr.getSomes([
+      Option.map(
+        Option.fromUndefinedOr(filters.ownerUserId),
+        (ownerUserId) => sql`ownerUserId = ${ownerUserId}`,
+      ),
+      Option.map(Option.fromUndefinedOr(filters.status), (status) => sql`status = ${status}`),
+    ]);
+
   const listRecords = (filters: ListOrdersFilters) =>
     SqlSchema.findAll({
       Request: ListOrdersFiltersSchema,
       Result: SqlOrderModel,
-      execute: (filters) =>
-        filters.ownerUserId === undefined && filters.status === undefined
-          ? sql`
+      execute: (filters) => {
+        const whereClauses = buildListWhereClauses(filters);
+
+        return Option.match(Arr.head(whereClauses), {
+          onNone: () => sql`
           SELECT *
           FROM orders
-          ORDER BY createdAt, id
-        `
-          : filters.ownerUserId !== undefined && filters.status === undefined
-            ? sql`
-          SELECT *
-          FROM orders
-          WHERE ownerUserId = ${filters.ownerUserId}
-          ORDER BY createdAt, id
-        `
-            : filters.ownerUserId === undefined && filters.status !== undefined
-              ? sql`
-          SELECT *
-          FROM orders
-          WHERE status = ${filters.status}
-          ORDER BY createdAt, id
-        `
-              : sql`
-          SELECT *
-          FROM orders
-          WHERE ownerUserId = ${filters.ownerUserId}
-            AND status = ${filters.status}
           ORDER BY createdAt, id
         `,
+          onSome: () => sql`
+          SELECT *
+          FROM orders
+          WHERE ${sql.and(whereClauses)}
+          ORDER BY createdAt, id
+        `,
+        });
+      },
     })(filters);
 
   const save = Effect.fn("SqlOrderRepository.save")(function* (

--- a/backend/test/contracts/repository-contract.ts
+++ b/backend/test/contracts/repository-contract.ts
@@ -121,5 +121,44 @@ export const defineRepositoryContract = (name: string, run: RunTest) => {
         }),
       );
     });
+
+    it("filters orders by owner and by owner plus status", async () => {
+      await run(
+        Effect.gen(function* () {
+          const orderRepository = yield* OrderRepository;
+          const averyPending = makeOrder({
+            id: "order-0001",
+            createdAt: utc("2026-01-01T10:00:00.000Z"),
+            ownerUserId: "user-avery",
+            status: "pending",
+          });
+          const averyReady = makeOrder({
+            id: "order-0002",
+            createdAt: utc("2026-01-01T10:05:00.000Z"),
+            ownerUserId: "user-avery",
+            status: "ready",
+          });
+          const blakeReady = makeOrder({
+            id: "order-0003",
+            createdAt: utc("2026-01-01T10:10:00.000Z"),
+            ownerUserId: "user-blake",
+            status: "ready",
+          });
+
+          yield* orderRepository.save(blakeReady);
+          yield* orderRepository.save(averyReady);
+          yield* orderRepository.save(averyPending);
+
+          const averyOrders = yield* orderRepository.list({ ownerUserId: "user-avery" });
+          const averyReadyOrders = yield* orderRepository.list({
+            ownerUserId: "user-avery",
+            status: "ready",
+          });
+
+          assert.deepStrictEqual(averyOrders, [averyPending, averyReady]);
+          assert.deepStrictEqual(averyReadyOrders, [averyReady]);
+        }),
+      );
+    });
   });
 };


### PR DESCRIPTION
## Summary
- replace the four-way conditional order-list SQL branch with Effect SQL statement fragments
- build the optional WHERE clause from owner and status filters via `sql.and`
- extend the repository contract to cover owner-only and owner-plus-status filtering

## Verification
- bun run check
