### PR TITLE
chore(test): add MCP Miniflare benchmark script

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -26,6 +26,7 @@
     "fmt": "oxfmt --write .",
     "fmt:check": "oxfmt --check .",
     "knip": "knip --files --exports --no-config-hints",
+    "bench:mcp:miniflare": "bun run scripts/measure-mcp-miniflare.ts",
     "check": "bun run typecheck && bun run lint && bun run lint:custom && bun run fmt:check && bun run knip && bun run test",
     "test": "vitest run"
   },

--- a/backend/scripts/measure-mcp-miniflare.ts
+++ b/backend/scripts/measure-mcp-miniflare.ts
@@ -1,0 +1,48 @@
+import * as Effect from "effect/Effect";
+import * as Path from "effect/Path";
+import { measureMcpMiniflareBootstrap, measureMcpWorkerBundle } from "../test/support/McpMiniflare";
+
+const defaultIterations = 7;
+
+const round = (value: number): number => Math.round(value * 100) / 100;
+
+const summarize = (values: ReadonlyArray<number>) => {
+  const total = values.reduce((sum, value) => sum + value, 0);
+
+  return {
+    averageMs: round(total / values.length),
+    maxMs: round(Math.max(...values)),
+    minMs: round(Math.min(...values)),
+    samplesMs: values.map(round),
+  };
+};
+
+const parseIterations = (value: string | undefined): number => {
+  const parsed = Number.parseInt(value ?? "", 10);
+
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return defaultIterations;
+  }
+
+  return parsed;
+};
+
+const program = Effect.gen(function* () {
+  const iterations = parseIterations(process.argv[2]);
+  const bundleSamples = yield* Effect.forEach(
+    Array.from({ length: iterations }, () => undefined),
+    () => measureMcpWorkerBundle(),
+    { concurrency: 1 },
+  );
+  const fullBootstrap = yield* measureMcpMiniflareBootstrap();
+
+  return {
+    bundle: summarize(bundleSamples),
+    fullBootstrap,
+    iterations,
+  };
+});
+
+const report = await Effect.runPromise(program.pipe(Effect.provide(Path.layer)));
+
+console.log(JSON.stringify(report, null, 2));

--- a/backend/test/support/McpMiniflare.ts
+++ b/backend/test/support/McpMiniflare.ts
@@ -112,16 +112,58 @@ const bundleWorkerScript = Effect.fn("bundleWorkerScript")(function* () {
   return output.text;
 });
 
-const decodeJsonRpcSuccessEnvelope = Schema.decodeUnknownEffect(JsonRpcSuccessEnvelopeSchema);
-const decodeJsonRpcErrorEnvelope = Schema.decodeUnknownOption(JsonRpcErrorEnvelopeSchema);
-
-export const createMcpMiniflareClient = async (): Promise<McpMiniflareClient> => {
-  const script = await Effect.runPromise(bundleWorkerScript().pipe(Effect.provide(Path.layer)));
-  const miniflare = new Miniflare({
+const createMiniflare = (script: string): Miniflare =>
+  new Miniflare({
     compatibilityDate: "2026-03-31",
     modules: true,
     script,
   });
+
+const decodeJsonRpcSuccessEnvelope = Schema.decodeUnknownEffect(JsonRpcSuccessEnvelopeSchema);
+const decodeJsonRpcErrorEnvelope = Schema.decodeUnknownOption(JsonRpcErrorEnvelopeSchema);
+
+export const measureMcpWorkerBundle = Effect.fn("measureMcpWorkerBundle")(function* () {
+  const bundleStart = performance.now();
+
+  yield* bundleWorkerScript();
+
+  return performance.now() - bundleStart;
+});
+
+export const measureMcpMiniflareBootstrap = Effect.fn("measureMcpMiniflareBootstrap")(function* () {
+  const bundleMs = yield* measureMcpWorkerBundle();
+  const script = yield* bundleWorkerScript();
+  const readyStart = performance.now();
+  const miniflare = createMiniflare(script);
+
+  yield* Effect.tryPromise({
+    try: () => miniflare.ready,
+    catch: () =>
+      new McpMiniflareTransportError({
+        message: "Miniflare worker could not be initialized.",
+      }),
+  });
+
+  const readyMs = performance.now() - readyStart;
+
+  yield* Effect.tryPromise({
+    try: () => miniflare.dispose(),
+    catch: () =>
+      new McpMiniflareTransportError({
+        message: "Miniflare worker could not be disposed.",
+      }),
+  });
+
+  return {
+    bundleMs,
+    readyMs,
+    totalMs: bundleMs + readyMs,
+  };
+});
+
+export const createMcpMiniflareClient = async (): Promise<McpMiniflareClient> => {
+  const script = await Effect.runPromise(bundleWorkerScript().pipe(Effect.provide(Path.layer)));
+  const miniflare = createMiniflare(script);
   const baseUrl = new URL("/mcp", await miniflare.ready).toString();
   const responses: Array<Response> = [];
 


### PR DESCRIPTION
## Summary
- add a reproducible backend benchmark command for the MCP Miniflare helper
- measure repeated esbuild bundle cost and a single full Miniflare bootstrap sample
- keep the current esbuild approach, but make future bundler decisions data-driven

## Verification
- bun run --cwd backend bench:mcp:miniflare
- bun run check
