### PR TITLE
feat(observability): redact genai payloads in collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Current limitation:
 - The current Cloudflare profile on this machine cannot manage AI Gateway resources, so `COFFEE_ASSISTANT_AI_GATEWAY=1` is not deployable here yet.
 - Workers Observability destinations require a separate `CLOUDFLARE_OBSERVABILITY_API_TOKEN` with account-level `Workers Observability Write` permission.
 - Set `OTEL_INGRESS_AUTHORIZATION=Bearer ...` if you want the collector ingress Worker to require a matching `Authorization` header on incoming export traffic; the companion Alchemy app will attach the same header to Workers observability destinations automatically.
-- Even once that permission issue is fixed, payload-suppression and OTel-export destination setup still need a later pass before we should treat model logging as fully production-hardened.
+- The collector now strips `gen_ai.prompt_json` and `gen_ai.completion_json` before upstream export, but broader payload-suppression and redaction policy still need a later pass before we should treat model logging as fully production-hardened.
 
 Expected workflow:
 

--- a/ops/otel-collector-cloudflare/README.md
+++ b/ops/otel-collector-cloudflare/README.md
@@ -47,6 +47,8 @@ This directory currently includes:
 - a container image definition for `otel/opentelemetry-collector-contrib`
 - a minimal collector config that accepts OTLP over HTTP and forwards traces
   and logs upstream
+- collector-side redaction for `gen_ai.prompt_json` and
+  `gen_ai.completion_json` before upstream export
 - a standalone Alchemy-managed Worker that fronts the collector container on
   `/v1/traces` and `/v1/logs`
 - a local `.env.example` for wiring the upstream backend
@@ -95,6 +97,12 @@ When this is set, the Alchemy destination resources will attach the matching
 `Authorization` header automatically for Workers observability exports.
 This is the recommended baseline hardening for the ingress path.
 
+The collector also deletes `gen_ai.prompt_json` and `gen_ai.completion_json`
+attributes before forwarding telemetry upstream.
+That matches the Cloudflare AI Gateway OTEL attribute names for raw prompt and
+completion payloads, so future AI Gateway exports do not leak those fields by
+default.
+
 Set `CLOUDFLARE_OBSERVABILITY_API_TOKEN` to an account-level Cloudflare API
 token with `Workers Observability Write` permission.
 The current Alchemy Cloudflare OAuth flow is enough to deploy Workers and
@@ -129,6 +137,8 @@ Verification note:
   `opentelemetry-traces` and `opentelemetry-logs`.
 - Cloudflare telemetry queries also showed the ingress Worker receiving
   `POST /v1/logs` after real requests hit the main app Worker.
+- The collector config now strips `gen_ai.prompt_json` and
+  `gen_ai.completion_json` before upstream export.
 
 ## Notes For SigNoz
 

--- a/ops/otel-collector-cloudflare/otelcol/config.yaml
+++ b/ops/otel-collector-cloudflare/otelcol/config.yaml
@@ -5,6 +5,12 @@ receivers:
         endpoint: 0.0.0.0:4318
 
 processors:
+  attributes/redact_gen_ai_payloads:
+    actions:
+      - key: gen_ai.prompt_json
+        action: delete
+      - key: gen_ai.completion_json
+        action: delete
   batch: {}
   memory_limiter:
     check_interval: 1s
@@ -28,9 +34,9 @@ service:
   pipelines:
     traces:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, attributes/redact_gen_ai_payloads, batch]
       exporters: [otlphttp/upstream]
     logs:
       receivers: [otlp]
-      processors: [memory_limiter, batch]
+      processors: [memory_limiter, attributes/redact_gen_ai_payloads, batch]
       exporters: [otlphttp/upstream]


### PR DESCRIPTION
## Summary
- delete `gen_ai.prompt_json` and `gen_ai.completion_json` in the collector before upstream export
- apply the redaction in both traces and logs pipelines
- document the active redaction baseline in the observability docs

## Verification

- `bun run check`
- `bun run --cwd ops/otel-collector-cloudflare/worker check`

```
docker run --rm \
  -e UPSTREAM_OTLP_HTTP_ENDPOINT=https://example.com/v1 \
  -e UPSTREAM_OTLP_AUTHORIZATION=Bearer:test \
  -v "$PWD/ops/otel-collector-cloudflare/otelcol/config.yaml:/etc/otelcol/config.yaml:ro" \
  otel/opentelemetry-collector-contrib:0.148.0 \
  validate --config=/etc/otelcol/config.yaml
```