### PR TITLE
docs(deploy): mark stateful resource slugs as migration-sensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,11 @@ That directory now includes a standalone Alchemy-managed companion Worker for
 collector ingress, separate from the main app so the collector can be deployed
 and destroyed independently.
 
+One important deployment note: the Alchemy app names, website resource name,
+and observability destination base names are stateful deployment identities.
+Do not rename them casually. Treat any rename as a deliberate migration that
+may recreate resources or fork existing Cloudflare/Alchemy state.
+
 Verification status:
 
 - Workers Observability destinations successfully delivered both datasets on April 11, 2026:

--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -7,6 +7,8 @@ import {
   collectorTraceDestinationName,
 } from "./ops/otel-collector-cloudflare/destination-names.ts";
 
+// This physical app name is part of the deployed Alchemy/Cloudflare identity.
+// Do not rename it casually; treat any change as a state migration.
 const app = await alchemy("effect-v4-onion", {
   password: process.env.ALCHEMY_PASSWORD,
   stateStore: process.env.ALCHEMY_STATE_TOKEN
@@ -31,6 +33,8 @@ export const assistantGateway = aiGatewayEnabled
     })
   : undefined;
 
+// This resource name is also stateful. Renaming it can recreate the website
+// resource or fork deployment state.
 export const website = await Website("onion", {
   url: true,
   compatibility: "node",

--- a/ops/otel-collector-cloudflare/alchemy.run.ts
+++ b/ops/otel-collector-cloudflare/alchemy.run.ts
@@ -8,6 +8,8 @@ import {
 } from "./destination-names.ts";
 import { WorkersObservabilityDestination } from "./observability-destination.ts";
 
+// This physical app name is part of the deployed collector identity.
+// Do not rename it without a migration plan for state and destinations.
 const app = await alchemy("effect-v4-onion-otel", {
   password: process.env.ALCHEMY_PASSWORD,
   stateStore: process.env.ALCHEMY_STATE_TOKEN

--- a/ops/otel-collector-cloudflare/destination-names.ts
+++ b/ops/otel-collector-cloudflare/destination-names.ts
@@ -8,6 +8,8 @@ const sanitizeStage = (value: string): string =>
 const currentStage = (): string =>
   sanitizeStage(process.env.ALCHEMY_STAGE ?? "default") || "default";
 
+// Destination names are stateful Cloudflare observability identities.
+// Renaming them can orphan or recreate destinations instead of updating them.
 const destinationBaseName = (): string =>
   `effect-v4-onion-otel-${currentStage()}`;
 


### PR DESCRIPTION
## Summary
- mark the main Alchemy app, collector app, and observability destination names as stateful deployment identities
- document that renaming these slugs should be treated as a migration, not a cosmetic cleanup
- make the deployment risk explicit in both code and the root README

## Verification
- bun run check
