### PR TITLE
feat(ui): surface authenticated user ids

### DIFF
--- a/ui/src/features/auth/components/SessionCard.stories.tsx
+++ b/ui/src/features/auth/components/SessionCard.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { expect, fn, userEvent, within } from "storybook/test";
+import { SessionCard } from "#features/auth/components/SessionCard.tsx";
+
+const meta = {
+  title: "Auth/Session/SessionCard",
+  component: SessionCard,
+  tags: ["autodocs"],
+  args: {
+    isPending: false,
+    onSignOut: fn().mockResolvedValue(undefined),
+    viewer: {
+      displayName: "Kevin Chen",
+      kind: "staff",
+      userId: "user_01hs2f5q4rt8n5v3w2x6y7z8aa",
+    },
+  },
+} satisfies Meta<typeof SessionCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const SignedIn: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText(/kevin chen/i)).toBeInTheDocument();
+    await expect(canvas.getByText(/user id/i)).toBeInTheDocument();
+    await expect(canvas.getByText(args.viewer.userId)).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByRole("button", { name: /sign out/i }));
+    await expect(args.onSignOut).toHaveBeenCalledTimes(1);
+  },
+};

--- a/ui/src/features/auth/components/SessionCard.tsx
+++ b/ui/src/features/auth/components/SessionCard.tsx
@@ -3,6 +3,7 @@ import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Card } from "#shared/ui/retroui/Card.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
 import type { AuthenticatedViewer } from "#features/auth/lib/viewer.ts";
+import { useState } from "react";
 
 interface SessionCardProps {
   viewer: AuthenticatedViewer;
@@ -12,6 +13,19 @@ interface SessionCardProps {
 
 export function SessionCard(inputProps: SessionCardProps) {
   const { isPending, viewer, onSignOut } = inputProps;
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "failed">("idle");
+  const canCopyUserId = navigator.clipboard?.writeText !== undefined;
+
+  const copyUserId = () => {
+    if (!canCopyUserId) {
+      return;
+    }
+
+    void navigator.clipboard.writeText(viewer.userId).then(
+      () => setCopyState("copied"),
+      () => setCopyState("failed"),
+    );
+  };
 
   return (
     <Card className="w-full border-border">
@@ -29,6 +43,28 @@ export function SessionCard(inputProps: SessionCardProps) {
           <Text as="p" className="text-sm text-muted-foreground">
             Orders placed here are scoped to your account.
           </Text>
+          <div className="flex flex-wrap items-center gap-2 pt-1">
+            <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+              User ID
+            </Text>
+            <code className="rounded border border-border bg-muted px-2 py-1 font-mono text-xs">
+              {viewer.userId}
+            </code>
+            {canCopyUserId ? (
+              <Button
+                className="min-w-24 justify-center"
+                size="sm"
+                variant="outline"
+                onClick={copyUserId}
+              >
+                {copyState === "copied"
+                  ? "Copied"
+                  : copyState === "failed"
+                    ? "Copy failed"
+                    : "Copy ID"}
+              </Button>
+            ) : null}
+          </div>
         </div>
         <Button disabled={isPending} variant="outline" onClick={() => void onSignOut()}>
           Sign out


### PR DESCRIPTION
## Summary
- show the authenticated `userId` in the signed-in session card for both customer and staff workspaces
- add a lightweight copy affordance so staff allowlist setup does not require reading values out of network responses
- add Storybook coverage for the signed-in card so the UI check path exercises the new surface

## Verification
- `bun run --cwd ui check`
- `bun run check`