### PR TITLE
chore(tooling): add effect tsgo integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ bun install
 
 This repo uses Bun workspaces. The root `bun install` covers both [`backend/`](./backend) and [`ui/`](./ui).
 Turborepo is the canonical root task runner for dev, build, and quality checks, so repeated runs can reuse the `.turbo` cache across workspaces and `--affected` can skip unrelated work.
-`bun install` also installs and prewarms the local Git hooks unless `CI` is set. If you need to refresh them manually, run `bun run hooks:install`.
+`bun install` also installs and prewarms the local Git hooks unless `CI` is set. The repo now includes `@effect/tsgo` at the root with the `@effect/language-service` plugin enabled in the main backend and UI tsconfigs, but the binary patch stays opt-in because the upstream tool is still alpha. Use `bun run tsgo:patch` to try the Effect language service binary locally, and `bun run tsgo:unpatch` to restore the stock `@typescript/native-preview` binary.
+For VS Code or Cursor, install the `@typescript/native-preview` extension and make sure the native TypeScript server is active so the workspace plugin configuration can load when you opt into `@effect/tsgo`.
 
 Run the app:
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,6 @@
     "@effect/vitest": "4.0.0-beta.47",
     "@types/bun": "^1.3.8",
     "@types/node": "^25.5.0",
-    "@typescript/native-preview": "7.0.0-dev.20260330.1",
     "esbuild": "^0.27.4",
     "find-up": "^8.0.0",
     "goke": "^6.3.2",

--- a/backend/src/presentation/cli/main.ts
+++ b/backend/src/presentation/cli/main.ts
@@ -1,15 +1,16 @@
 import * as BunServices from "@effect/platform-bun/BunServices";
 import * as BunRuntime from "@effect/platform-bun/BunRuntime";
 import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
 import { BunCoffeeAppLive } from "#runtime/bun/live";
 import { CoffeeOrderApp } from "#service/CoffeeOrderApp";
 import { CurrentActor, systemActor } from "#service/CurrentActor";
 import { runCoffeeCli } from "./command.ts";
 
-runCoffeeCli.pipe(
-  Effect.provide(CoffeeOrderApp.layer),
-  Effect.provideService(CurrentActor, systemActor),
-  Effect.provide(BunCoffeeAppLive),
-  Effect.provide(BunServices.layer),
-  BunRuntime.runMain,
+const CoffeeCliLive = Layer.mergeAll(
+  Layer.succeed(CurrentActor)(systemActor),
+  BunServices.layer,
+  CoffeeOrderApp.layer.pipe(Layer.provide(BunCoffeeAppLive)),
 );
+
+runCoffeeCli.pipe(Effect.provide(CoffeeCliLive), BunRuntime.runMain);

--- a/backend/src/presentation/http/api.test.ts
+++ b/backend/src/presentation/http/api.test.ts
@@ -51,7 +51,9 @@ describe("http api success responses", () => {
       const response = yield* HttpClient.post("/orders", {
         body: HttpBody.jsonUnsafe(orderPayload),
       });
-      const body = Schema.decodeUnknownSync(CreatedOrderResponseSchema)(yield* response.json);
+      const body = yield* Schema.decodeUnknownEffect(CreatedOrderResponseSchema)(
+        yield* response.json,
+      );
 
       assert.strictEqual(response.status, 200);
       assert.strictEqual(body.id, "order-0001");
@@ -71,7 +73,7 @@ describe("http api error responses", () => {
           size: "medium",
         }),
       });
-      const body = Schema.decodeUnknownSync(InvalidOrderInputError)(yield* response.json);
+      const body = yield* Schema.decodeUnknownEffect(InvalidOrderInputError)(yield* response.json);
 
       assert.strictEqual(response.status, 400);
       assert.strictEqual(body._tag, "InvalidOrderInputError");
@@ -82,7 +84,7 @@ describe("http api error responses", () => {
   it.effect("maps missing orders to 404", () =>
     Effect.gen(function* () {
       const response = yield* HttpClient.get("/orders/order-9999");
-      const body = Schema.decodeUnknownSync(OrderNotFoundError)(yield* response.json);
+      const body = yield* Schema.decodeUnknownEffect(OrderNotFoundError)(yield* response.json);
 
       assert.strictEqual(response.status, 404);
       assert.strictEqual(body._tag, "OrderNotFoundError");
@@ -97,7 +99,7 @@ describe("http api error responses", () => {
         payload: orderPayload,
       });
       const response = yield* HttpClient.post(`/orders/${created.id}/mark-ready`);
-      const body = Schema.decodeUnknownSync(InvalidOrderStatusTransitionError)(
+      const body = yield* Schema.decodeUnknownEffect(InvalidOrderStatusTransitionError)(
         yield* response.json,
       );
 
@@ -114,7 +116,7 @@ describe("http api error responses", () => {
       const response = yield* HttpClient.post("/orders", {
         body: HttpBody.jsonUnsafe(orderPayload),
       });
-      const body = Schema.decodeUnknownSync(InternalAppError)(yield* response.json);
+      const body = yield* Schema.decodeUnknownEffect(InternalAppError)(yield* response.json);
 
       assert.strictEqual(response.status, 500);
       assert.strictEqual(body._tag, "InternalAppError");

--- a/backend/src/presentation/mcp/miniflare.worker.test.ts
+++ b/backend/src/presentation/mcp/miniflare.worker.test.ts
@@ -173,17 +173,16 @@ const verifyStringRequestIds = (request: McpRequest, responses: ReadonlyArray<Re
       },
     );
     const response = responses[0];
-    let json: Schema.Schema.Type<typeof StringIdResponseSchema> | null = null;
 
-    if (response !== undefined) {
-      json = Schema.decodeUnknownSync(StringIdResponseSchema)(
-        yield* Effect.promise(async () => response.json()),
-      );
-    }
+    assert.ok(response !== undefined);
+
+    const json = yield* Effect.promise(async () => response.json()).pipe(
+      Effect.flatMap(Schema.decodeUnknownEffect(StringIdResponseSchema)),
+    );
 
     assert.strictEqual(initialize.protocolVersion, "2025-06-18");
     assert.strictEqual(initialize.serverInfo.name, "Coffee Orders MCP");
-    assert.strictEqual(json?.id, "init");
+    assert.strictEqual(json.id, "init");
   });
 
 const runMcpTest = async (

--- a/backend/src/service/use-cases/coffee-order.test.ts
+++ b/backend/src/service/use-cases/coffee-order.test.ts
@@ -1,6 +1,7 @@
 import { assert, describe, it } from "@effect/vitest";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as Schema from "effect/Schema";
 import { InMemoryCoffeeAppLive } from "#external/live";
 import { CurrentActor, systemActor } from "#service/CurrentActor";
 import {
@@ -69,12 +70,12 @@ describe("coffee order workflow", () => {
         drinkId: "tea",
         size: "small",
       });
-      const encodedFirst = JSON.parse(JSON.stringify(first));
+      const encodedFirst = yield* Schema.encodeUnknownEffect(Schema.UnknownFromJsonString)(first);
 
       assert.strictEqual(first.id, "order-0001");
       assert.strictEqual(second.id, "order-0002");
       assert.isTrue(DateTime.isUtc(first.createdAt));
-      assert.match(encodedFirst.createdAt, /^\d{4}-\d{2}-\d{2}T/);
+      assert.match(encodedFirst, /"createdAt":"\d{4}-\d{2}-\d{2}T/);
     }).pipe(provideSystemActor, Effect.provide(InMemoryCoffeeAppLive)),
   );
 });

--- a/backend/test/integration/llm-mcp-client.test.ts
+++ b/backend/test/integration/llm-mcp-client.test.ts
@@ -81,7 +81,10 @@ describe("MCP tools with persistence verification", () => {
         // Run workflow with timeout
         const result = yield* llmMcpWorkflow().pipe(Effect.timeout("60 seconds"));
 
-        assert.ok(result.success, `Expected success but got: ${JSON.stringify(result)}`);
+        assert.ok(
+          result.success,
+          `Expected success but got: ${Bun.inspect(result, { depth: Infinity })}`,
+        );
         assert.ok(result.orderId, `Expected order ID to be set`);
         assert.match(result.orderId, /^order-\d{4}$/);
         assert.strictEqual(result.getOrderResult.structuredContent.id, result.orderId);

--- a/backend/test/integration/llm-mcp-client.test.ts
+++ b/backend/test/integration/llm-mcp-client.test.ts
@@ -83,7 +83,7 @@ describe("MCP tools with persistence verification", () => {
 
         assert.ok(
           result.success,
-          `Expected success but got: ${Bun.inspect(result, { depth: Infinity })}`,
+          `Expected success but got success=${String(result.success)} orderId=${result.orderId}`,
         );
         assert.ok(result.orderId, `Expected order ID to be set`);
         assert.match(result.orderId, /^order-\d{4}$/);

--- a/backend/test/support/McpMiniflare.ts
+++ b/backend/test/support/McpMiniflare.ts
@@ -121,6 +121,7 @@ const createMiniflare = (script: string): Miniflare =>
 
 const decodeJsonRpcSuccessEnvelope = Schema.decodeUnknownEffect(JsonRpcSuccessEnvelopeSchema);
 const decodeJsonRpcErrorEnvelope = Schema.decodeUnknownOption(JsonRpcErrorEnvelopeSchema);
+const encodeJsonString = Schema.encodeUnknownEffect(Schema.UnknownFromJsonString);
 
 export const measureMcpWorkerBundle = Effect.fn("measureMcpWorkerBundle")(function* () {
   const bundleStart = performance.now();
@@ -179,17 +180,18 @@ export const createMcpMiniflareClient = async (): Promise<McpMiniflareClient> =>
     },
   ) =>
     Effect.gen(function* () {
+      const requestBody = yield* encodeJsonString({
+        id: options?.id ?? nextRequestId(),
+        jsonrpc: "2.0",
+        method,
+        params,
+      });
       const response = yield* Effect.tryPromise({
         try: () =>
           fetch(baseUrl, {
             method: "POST",
             headers: createMcpRequestHeaders(sessionId),
-            body: JSON.stringify({
-              id: options?.id ?? nextRequestId(),
-              jsonrpc: "2.0",
-              method,
-              params,
-            }),
+            body: requestBody,
           }),
         catch: () =>
           new McpMiniflareTransportError({

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json",
   "compilerOptions": {
     "target": "ESNext",
     "module": "ESNext",
@@ -10,7 +11,8 @@
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true
+    "exactOptionalPropertyTypes": true,
+    "plugins": [{ "name": "@effect/language-service" }]
   },
   "include": ["src/**/*.ts", "test/**/*.ts"]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,9 @@
     "": {
       "name": "effect-coffee-shop",
       "devDependencies": {
+        "@effect/tsgo": "0.4.0",
         "@j178/prek": "0.3.8",
+        "@typescript/native-preview": "7.0.0-dev.20260330.1",
         "alchemy": "0.90.1",
         "turbo": "^2.9.2",
       },
@@ -30,7 +32,6 @@
         "@effect/vitest": "4.0.0-beta.47",
         "@types/bun": "^1.3.8",
         "@types/node": "^25.5.0",
-        "@typescript/native-preview": "7.0.0-dev.20260330.1",
         "esbuild": "^0.27.4",
         "find-up": "^8.0.0",
         "goke": "^6.3.2",
@@ -84,7 +85,6 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@typescript/native-preview": "7.0.0-dev.20260330.1",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/browser": "^4.1.2",
         "@vitest/browser-playwright": "^4.1.2",
@@ -254,6 +254,22 @@
     "@effect/sql-d1": ["@effect/sql-d1@4.0.0-beta.47", "", { "dependencies": { "@cloudflare/workers-types": "^4.20260131.0" }, "peerDependencies": { "effect": "^4.0.0-beta.47" } }, "sha512-uRO3NdrUwKaRenm0p9VXS+BzSvS75r0oOeh5scFrIpFH+NWLP/kkjZV7DgLG7i54te8d7b9UWbXmqS6tInxOnQ=="],
 
     "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@4.0.0-beta.47", "", { "peerDependencies": { "effect": "^4.0.0-beta.47" } }, "sha512-jhYjfY7EHj8ulgi0sq3fwjXxpKlNeXGb53FCsX8pflEuJPBEtiTaEIJ0gbg4bPV2wLTdpQaBc7brsRP2dE+FLw=="],
+
+    "@effect/tsgo": ["@effect/tsgo@0.4.0", "", { "optionalDependencies": { "@effect/tsgo-darwin-arm64": "0.4.0", "@effect/tsgo-darwin-x64": "0.4.0", "@effect/tsgo-linux-arm": "0.4.0", "@effect/tsgo-linux-arm64": "0.4.0", "@effect/tsgo-linux-x64": "0.4.0", "@effect/tsgo-win32-arm64": "0.4.0", "@effect/tsgo-win32-x64": "0.4.0" }, "bin": { "effect-tsgo": "dist/effect-tsgo.js" } }, "sha512-RhB8EW97Bu1OW1fOZnMJsX9Et1IDvByMSPE/fnY+/a5+VDEUniM+Q4PMPVYOdcRRSKHrPeEVzQLSSjcaBPIqCQ=="],
+
+    "@effect/tsgo-darwin-arm64": ["@effect/tsgo-darwin-arm64@0.4.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-O7dg5zdT0x8/QRF1LTsTKO89QwKOd1WTar1qqZV3SbEGMJeld4klQXMU4Uzpa8JMybDFlyhU2aBEiKxwllKhIQ=="],
+
+    "@effect/tsgo-darwin-x64": ["@effect/tsgo-darwin-x64@0.4.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-gS1wqbJFbeVFad9qNe8O75Lcth5bxaDI4DbXXK9vBD4BeX9MhY9kv78/Ror89xMtQqiyaOfUf3WbCwHs0TQQHw=="],
+
+    "@effect/tsgo-linux-arm": ["@effect/tsgo-linux-arm@0.4.0", "", { "os": "linux", "cpu": "arm" }, "sha512-4i8R0CR0cJigpH8FiaGB90auu8fZ5cH4lK1v4U/Ji0CYlQzCOQ9ytXaAxvFN3vVdkfKT1QEaisoSrwv01TkDkQ=="],
+
+    "@effect/tsgo-linux-arm64": ["@effect/tsgo-linux-arm64@0.4.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-H8TK5KvZVosevH0V8zi6vHZWXchHQg87Y5OVGqPB2pnJ3zx0x9JflVENg+yWbovP7tKkd+EB14Nn+L98Mm7hlA=="],
+
+    "@effect/tsgo-linux-x64": ["@effect/tsgo-linux-x64@0.4.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+JW566Kitimkr/1t4aeVYqKu3EMufMNgfGo+HH31yFD04IGBXwfqOjLVrHrp8wzh0s3NNABHkQmT1G5TnkMRlw=="],
+
+    "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.4.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-KuGpUb2/hKtTSGfBksydVaN94DUSGUUxG7hQUaPvEo87WtHYBnLl7xqpdlKzKxvmim3gv2i7uzkbL6ef65+lqw=="],
+
+    "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.4.0", "", { "os": "win32", "cpu": "x64" }, "sha512-pI5MMLiKR9fFmuPtqG+gyudrmqfnrPR7Cf+ENHzn+XXgkARA9UmLW9VC0GN1h3SH1oQiQp3Qw814LQ1qRizPkA=="],
 
     "@effect/vitest": ["@effect/vitest@4.0.0-beta.47", "", { "peerDependencies": { "effect": "^4.0.0-beta.47", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-1KdMUseTTLP+OeEmWwN3PzyMrhHBy47tHol2lotl+GkrmGameXhtD8xFfiO4BIj92jKMY3RBTkIemVBWaG8UyA=="],
 

--- a/package.json
+++ b/package.json
@@ -47,12 +47,16 @@
     "lint:custom:affected": "turbo run lint:custom --affected",
     "affected:packages": "turbo query affected --packages",
     "affected:tasks": "turbo query affected",
+    "tsgo:patch": "effect-tsgo patch",
+    "tsgo:unpatch": "effect-tsgo unpatch",
     "hooks:install": "prek install --overwrite --prepare-hooks",
     "hooks:run:pre-commit": "prek run --all-files --stage pre-commit",
     "hooks:run:pre-push": "prek run --all-files --stage pre-push"
   },
   "devDependencies": {
+    "@effect/tsgo": "0.4.0",
     "@j178/prek": "0.3.8",
+    "@typescript/native-preview": "7.0.0-dev.20260330.1",
     "alchemy": "0.90.1",
     "turbo": "^2.9.2"
   },

--- a/ui/package.json
+++ b/ui/package.json
@@ -64,7 +64,6 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@typescript/native-preview": "7.0.0-dev.20260330.1",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/browser": "^4.1.2",
     "@vitest/browser-playwright": "^4.1.2",

--- a/ui/tsconfig.app.json
+++ b/ui/tsconfig.app.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json",
   "compilerOptions": {
     "target": "ES2023",
     "useDefineForClassFields": true,
@@ -24,7 +25,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "plugins": [{ "name": "@effect/language-service" }]
   },
   "include": ["src", ".storybook/**/*.tsx"]
 }

--- a/ui/tsconfig.node.json
+++ b/ui/tsconfig.node.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://raw.githubusercontent.com/Effect-TS/tsgo/refs/heads/main/schema.json",
   "compilerOptions": {
     "target": "ES2023",
     "lib": ["ES2023"],
@@ -20,7 +21,8 @@
     "noUnusedParameters": true,
     "erasableSyntaxOnly": true,
     "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUncheckedSideEffectImports": true,
+    "plugins": [{ "name": "@effect/language-service" }]
   },
   "include": ["vite.config.ts", "vite.shared.ts", "vitest.config.ts", ".storybook/**/*.ts"]
 }


### PR DESCRIPTION
## What changed
- added `@effect/tsgo` and `@typescript/native-preview` at the repo root so the Effect tsgo toolchain is installed once for the workspace
- added `bun run tsgo:patch` and `bun run tsgo:unpatch` helper scripts
- enabled the `@effect/language-service` plugin and schema metadata in the main backend and UI tsconfigs
- documented the new setup and editor expectation in the root README
- removed duplicate `@typescript/native-preview` entries from the backend and UI package manifests
- cleaned the backend findings that `effect-tsgo` surfaced in the CLI and test codepaths
- kept the MCP persistence test assertion message Node-safe so the existing Vitest runtime and pre-push gate still pass

## Why
I used `nia` to inspect `Effect-TS/tsgo` and confirmed that the upstream install shape is:
- keep `@typescript/native-preview`
- add `@effect/tsgo`
- configure the `@effect/language-service` tsconfig plugin
- use `effect-tsgo patch` when opting into the Effect language service binary

This repo was already using the stock `tsgo` binary from `@typescript/native-preview`, but it was not wired for `@effect/tsgo`.

## Important caveat
I did try the patched `effect-tsgo` binary locally. It surfaces useful Effect diagnostics, and this branch fixes the backend findings it revealed around sync schema decoding, raw JSON test boundaries, and CLI layer composition. But in this codebase the patched language-service path still introduces a hard `TS2589` (`Type instantiation is excessively deep and possibly infinite.`) that the stock native-preview binary does not report. Because of that, this PR keeps the patch flow opt-in instead of auto-patching during `bun install`.

## Developer impact
- the repo is prepared for `@effect/tsgo`
- stock `bun run typecheck` behavior stays green by default
- anyone who wants to try the alpha Effect language service binary locally can run `bun run tsgo:patch`
- `bun run tsgo:unpatch` restores the stock native-preview binary

## Validation
- `bun run typecheck`
- `bun run fmt:check`
- `bun run check:affected`
- `bun run --cwd backend lint`
- `bun run --cwd backend test`
- installed Playwright Chromium locally so the existing UI browser tests in the affected gate could run
