### PR TITLE
feat(backend): add dev:local:full script with SQLite persistence

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -17,6 +17,7 @@
     "mcp:stdio": "bun run src/presentation/mcp/stdio-main.ts",
     "mcp:http": "bun run src/presentation/mcp/http-main.ts",
     "dev:local:api": "bun run src/presentation/dev/local-backend-main.ts",
+    "dev:local:full": "bun run src/presentation/dev/local-full-backend-main.ts",
     "typecheck": "tsgo --noEmit",
     "lint": "oxlint --disable-nested-config .",
     "lint:fix": "oxlint --disable-nested-config --fix .",

--- a/backend/src/presentation/dev/local-full-backend-main.ts
+++ b/backend/src/presentation/dev/local-full-backend-main.ts
@@ -1,0 +1,20 @@
+import * as Layer from "effect/Layer";
+import { BunCoffeeAppLive } from "#runtime/bun/live";
+import { CoffeeHttpApiLive } from "#presentation/http/api";
+import { startCoffeeBunServer } from "#presentation/http/bun-server";
+import { CoffeeMcpHttpLive } from "#presentation/mcp/server";
+
+// Local "full" backend:
+//   - Datastore: SQLite via @effect/sql-sqlite-bun (persists under .data/)
+//   - Auth: anonymous actor — Better-Auth's D1 integration is not wired here
+//     (see #presentation/auth/local.ts for context).
+//   - Assistant: if CLOUDFLARE_ACCOUNT_ID + CLOUDFLARE_API_TOKEN are set, the
+//     existing Workers AI REST path is used; otherwise /assistant returns 503.
+//
+// A zero-Cloudflare AI path (OpenAI/Anthropic) is a planned follow-up.
+
+await startCoffeeBunServer({
+  appLayer: BunCoffeeAppLive,
+  portEnv: "COFFEE_HTTP_PORT",
+  routes: Layer.mergeAll(CoffeeHttpApiLive, CoffeeMcpHttpLive),
+});


### PR DESCRIPTION
Adds a `dev:local:full` script that runs the backend with SQLite persistence instead of ephemeral in-memory storage.