### PR TITLE
feat(ui): drive staff order inspection from router search params

### DIFF
--- a/ui/src/app/router.tsx
+++ b/ui/src/app/router.tsx
@@ -1,10 +1,35 @@
-import { Outlet, createRootRoute, createRoute, createRouter } from "@tanstack/react-router";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import {
+  Outlet,
+  createRootRoute,
+  createRoute,
+  createRouter,
+  type SearchSchemaInput,
+} from "@tanstack/react-router";
 import { NotFoundPage } from "#app/NotFoundPage.tsx";
 import { appRoutes } from "#app/routes.ts";
 import { AssistantLandingPage } from "#features/assistant/components/AssistantLandingPage.tsx";
 import { AgentApprovalPage } from "#features/auth/components/AgentApprovalPage.tsx";
 import { CoffeeCustomerPage } from "#features/coffee-shop/components/CoffeeCustomerPage.tsx";
 import { CoffeeStaffPage } from "#features/coffee-shop/components/CoffeeStaffPage.tsx";
+
+const StaffRouteSearchSchema = Schema.Struct({
+  order: Schema.optionalKey(Schema.String),
+});
+
+type StaffRouteSearch = Schema.Schema.Type<typeof StaffRouteSearchSchema>;
+type StaffRouteSearchInput = SearchSchemaInput &
+  Schema.Codec.Encoded<typeof StaffRouteSearchSchema>;
+
+const emptyStaffRouteSearch = {} as const satisfies StaffRouteSearch;
+
+function validateStaffRouteSearch(input: StaffRouteSearchInput): StaffRouteSearch {
+  return Option.match(Schema.decodeUnknownOption(StaffRouteSearchSchema)(input), {
+    onNone: () => emptyStaffRouteSearch,
+    onSome: (search) => search,
+  });
+}
 
 const rootRoute = createRootRoute({
   component: () => <Outlet />,
@@ -45,6 +70,7 @@ const staffRoute = createRoute({
   component: CoffeeStaffPage,
   getParentRoute: () => rootRoute,
   path: appRoutes.staff,
+  validateSearch: validateStaffRouteSearch,
 });
 
 const routeTree = rootRoute.addChildren([

--- a/ui/src/features/coffee-shop/hooks/useStaffWorkspace.ts
+++ b/ui/src/features/coffee-shop/hooks/useStaffWorkspace.ts
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useNavigate, useSearch } from "@tanstack/react-router";
 import { toast } from "sonner";
+import { appRoutes } from "#app/routes.ts";
 import { useViewerQuery } from "#features/auth/hooks/useViewerQuery.ts";
 import {
   anonymousViewer,
@@ -37,6 +38,17 @@ function getStaffQueueSnapshot(orders: readonly CoffeeOrder[], selectedOrderId: 
   };
 }
 
+function updateSelectedOrderSearch<TSearch extends { order?: string }>(
+  previous: TSearch,
+  orderId: string | null,
+): TSearch {
+  if (orderId === null) {
+    return { ...previous, order: undefined };
+  }
+
+  return { ...previous, order: orderId };
+}
+
 function useOrderActionHandler(
   orderActionMutation: ReturnType<typeof useOrderActionMutation>,
   setSelectedOrderId: (orderId: string | null) => void,
@@ -58,13 +70,24 @@ export function useStaffWorkspace() {
   const canLoadOrders = isAuthenticatedViewer(viewer) && isStaffViewer(viewer);
   const ordersQuery = useOrdersQuery({ enabled: canLoadOrders });
   const orderActionMutation = useOrderActionMutation();
+  const navigate = useNavigate({ from: appRoutes.staff });
+  const selectedOrderId = useSearch({
+    from: appRoutes.staff,
+    select: (search) => search.order ?? null,
+  });
   const { theme, toggleTheme } = useThemePreference();
-  const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
   const orders = ordersQuery.data ?? emptyOrders;
   const { activeOrders, historyOrders, queueLoad, readyCount, selectedOrder } =
     getStaffQueueSnapshot(orders, selectedOrderId);
   const pendingOrderId = orderActionMutation.variables?.orderId ?? null;
   const errorMessage = getErrorMessage(viewerQuery.error?.message, ordersQuery.error?.message);
+  function setSelectedOrderId(orderId: string | null) {
+    void navigate({
+      resetScroll: false,
+      search: (previous) => updateSelectedOrderSearch(previous, orderId),
+      to: appRoutes.staff,
+    });
+  }
   const handleOrderAction = useOrderActionHandler(orderActionMutation, setSelectedOrderId);
 
   return {


### PR DESCRIPTION
Builds on TanStack Router to drive staff order inspection state from URL search parameters, enabling shareable/filterable staff workspace views.