### PR TITLE
chore: enable Bun isolated global store

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ bun install
 ```
 
 This repo uses Bun workspaces and Bun Catalogs. The root `bun install` covers [`apps/*`](./apps) and [`domains/*/*`](./domains).
+Dependency installs use Bun's isolated linker with the global virtual store enabled, so package contents are shared from Bun's cache and project `node_modules` trees are mostly symlinks.
 Turborepo is the canonical root task runner for dev, build, and quality checks, so repeated runs can reuse the `.turbo` cache across workspaces and `--affected` can skip unrelated work.
 `bun install` also installs and prewarms the local Git hooks unless `CI` is set. The repo now includes `@effect/tsgo` at the root with the `@effect/language-service` plugin enabled in the main backend and UI tsconfigs, but the binary patch stays opt-in because the upstream tool is still alpha. Use `bun run tsgo:patch` to try the Effect language service binary locally, and `bun run tsgo:unpatch` to restore the stock `@typescript/native-preview` binary.
 For VS Code or Cursor, install the `@typescript/native-preview` extension and make sure the native TypeScript server is active so the workspace plugin configuration can load when you opt into `@effect/tsgo`.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,3 @@
+[install]
+linker = "isolated"
+globalStore = true


### PR DESCRIPTION
## Summary
- add a root bunfig.toml that makes Bun isolated installs explicit
- keep Bun's global virtual store enabled for shared package contents
- document the node_modules symlink layout in the install instructions

## Verification
- bun install --dry-run --frozen-lockfile
- bun install --frozen-lockfile
- bun run fmt:check --affected
- bun run check:affected