### PR TITLE
chore(alchemy): update to beta 36

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "catalog:",
+    "@effect/sql-d1": "catalog:",
     "@effect/vitest": "catalog:",
     "@types/bun": "catalog:",
     "@types/node": "catalog:",

--- a/bun.lock
+++ b/bun.lock
@@ -11,7 +11,7 @@
         "@effect/tsgo": "0.5.2",
         "@j178/prek": "0.3.13",
         "@typescript/native-preview": "7.0.0-dev.20260507.1",
-        "alchemy": "2.0.0-beta.35",
+        "alchemy": "2.0.0-beta.36",
         "effect": "4.0.0-beta.64",
         "fallow": "catalog:",
         "turbo": "^2.9.10",
@@ -35,6 +35,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "catalog:",
+        "@effect/sql-d1": "catalog:",
         "@effect/vitest": "catalog:",
         "@types/bun": "catalog:",
         "@types/node": "catalog:",
@@ -1453,7 +1454,7 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
-    "alchemy": ["alchemy@2.0.0-beta.35", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.31", "@ai-sdk/openai": "^3.0.23", "@ai-sdk/provider": "^3.0.8", "@aws-sdk/credential-providers": "^3.0.0", "@clack/prompts": "^0.11.0", "@distilled.cloud/aws": "^0.19.0", "@distilled.cloud/axiom": "^0.19.0", "@distilled.cloud/cloudflare": "^0.19.0", "@distilled.cloud/cloudflare-rolldown-plugin": "0.3.0", "@distilled.cloud/cloudflare-runtime": "0.3.2", "@distilled.cloud/cloudflare-vite-plugin": "0.2.0", "@distilled.cloud/core": "^0.19.0", "@distilled.cloud/neon": "^0.19.0", "@effect/vitest": ">=4.0.0-beta.60 || >=4.0.0", "@libsql/client": "^0.17.0", "@octokit/rest": "^22.0.1", "@smithy/node-config-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.3.4", "@smithy/types": "^4.8.1", "@types/aws-lambda": "^8.10.152", "@types/libsodium-wrappers": "^0.8.2", "ai": "^6.0.62", "aws4fetch": "^1.0.20", "capnweb": "^0.6.1", "fast-glob": "^3.3.2", "fast-xml-parser": "^5.3.4", "foreground-child": "^4.0.3", "ignore": "^7.0.5", "ink": "^6.3.1", "jszip": "^3.10.1", "libsodium-wrappers": "^0.8.3", "magic-string": "^0.30.21", "pathe": "^2.0.3", "pg": "^8.13.0", "picomatch": "^4.0.4", "proper-lockfile": "^4.1.2", "react": "^19.2.0", "rolldown": "1.0.0-rc.17", "sonda": "^0.11.1", "web-tree-sitter": "0.25.10", "yaml": "^2.0.0" }, "peerDependencies": { "@effect/platform-bun": ">=4.0.0-beta.60 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.60 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.60 || >=4.0.0", "drizzle-kit": ">=1.0.0-rc.1", "drizzle-orm": ">=1.0.0-rc.1", "effect": ">=4.0.0-beta.60 || >=4.0.0", "vite": "^8.0.7", "ws": "^8.20.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node", "@effect/sql-pg", "drizzle-kit", "drizzle-orm", "vite", "ws"], "bin": { "alchemy": "bin/cli.js" } }, "sha512-apGpTY+loZ48HCe1Qq3OfubQYcLyum6+l/l7eT9NSNEiPRcWmti1WVBfMrzdZzgCPwEttPDNziwXOqnXQM4Kqg=="],
+    "alchemy": ["alchemy@2.0.0-beta.36", "", { "dependencies": { "@ai-sdk/anthropic": "^3.0.31", "@ai-sdk/openai": "^3.0.23", "@ai-sdk/provider": "^3.0.8", "@aws-sdk/credential-providers": "^3.0.0", "@clack/prompts": "^0.11.0", "@distilled.cloud/aws": "^0.19.0", "@distilled.cloud/axiom": "^0.19.0", "@distilled.cloud/cloudflare": "^0.19.0", "@distilled.cloud/cloudflare-rolldown-plugin": "0.3.0", "@distilled.cloud/cloudflare-runtime": "0.3.2", "@distilled.cloud/cloudflare-vite-plugin": "0.2.0", "@distilled.cloud/core": "^0.19.0", "@distilled.cloud/neon": "^0.19.0", "@effect/vitest": ">=4.0.0-beta.60 || >=4.0.0", "@libsql/client": "^0.17.0", "@octokit/rest": "^22.0.1", "@smithy/node-config-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.3.4", "@smithy/types": "^4.8.1", "@types/aws-lambda": "^8.10.152", "@types/libsodium-wrappers": "^0.8.2", "ai": "^6.0.62", "aws4fetch": "^1.0.20", "capnweb": "^0.6.1", "fast-glob": "^3.3.2", "fast-xml-parser": "^5.3.4", "foreground-child": "^4.0.3", "ignore": "^7.0.5", "ink": "^6.3.1", "jszip": "^3.10.1", "libsodium-wrappers": "^0.8.3", "magic-string": "^0.30.21", "pathe": "^2.0.3", "pg": "^8.13.0", "picomatch": "^4.0.4", "proper-lockfile": "^4.1.2", "react": "^19.2.0", "rolldown": "1.0.0-rc.17", "sonda": "^0.11.1", "undici": "^7.16.0", "web-tree-sitter": "0.25.10", "yaml": "^2.0.0" }, "peerDependencies": { "@effect/platform-bun": ">=4.0.0-beta.60 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.60 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.60 || >=4.0.0", "drizzle-kit": ">=1.0.0-rc.1", "drizzle-orm": ">=1.0.0-rc.1", "effect": ">=4.0.0-beta.60 || >=4.0.0", "vite": "^8.0.7", "ws": "^8.20.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node", "@effect/sql-pg", "drizzle-kit", "drizzle-orm", "vite", "ws"], "bin": { "alchemy": "bin/cli.js" } }, "sha512-ULN0S8TfP+t8NpHHaG5KVqFNidB/T3DHx7V7q88JuekCgNU0fwAqzJKVvz3JqWV+XcbgrLgr/JLacviJuktYzA=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -2276,6 +2277,8 @@
     "@vitest/browser/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "ai/@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "alchemy/undici": ["undici@7.24.8", "", {}, "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ=="],
 
     "better-auth/@better-auth/core": ["@better-auth/core@1.6.9", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-ADFk5pwmLybmc+LvYvXJ6M1x2oY/EyYLkwLuH0x28FUq12DfjL0wnE7g+WRDf3yozDO+qIxTpFGXDGwLKbfz0w=="],
 

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "@effect/tsgo": "0.5.2",
     "@j178/prek": "0.3.13",
     "@typescript/native-preview": "7.0.0-dev.20260507.1",
-    "alchemy": "2.0.0-beta.35",
+    "alchemy": "2.0.0-beta.36",
     "effect": "4.0.0-beta.64",
     "turbo": "^2.9.10",
     "fallow": "catalog:"


### PR DESCRIPTION
## Summary

- Updates `alchemy` from `2.0.0-beta.35` to `2.0.0-beta.36`.
- Refreshes `bun.lock` for the new Alchemy tarball and its `undici` dependency.
- Declares `@effect/sql-d1` in `apps/backend` because its D1 Miniflare test support imports it directly under the isolated Bun install.

## New Alchemy Features And Possible Uses

| New feature in `2.0.0-beta.36` | What changed upstream | How we could theoretically leverage it |
| --- | --- | --- |
| Cloudflare Images binding | Adds `Cloudflare.Images()` as a Worker binding plus an Effect-native image client for image info, transforms, drawing, and output. | Add staff-managed menu item photos; validate uploaded images at the Worker boundary; generate thumbnails and optimized catalog images; create social/order-preview images; support future customer or staff image workflows without a separate image processing service. |
| Hyperdrive in Worker bindings | Allows `Hyperdrive` resources to be passed directly through Worker/Vite `bindings`, with deploy-time binding metadata and env inference. | Keep D1 for the current edge path while experimenting with Neon/Postgres for richer analytics, staff reporting, loyalty history, or higher-concurrency relational workloads; expose Postgres-backed data to the assistant/API from the same Cloudflare Worker runtime if D1 becomes limiting. |
| R2 bucket lifecycle rules | Adds `lifecycleRules` to `Cloudflare.R2Bucket` for automatic deletes, incomplete multipart upload cleanup, and `InfrequentAccess` transitions. | If we introduce R2 for receipts, exports, assistant transcripts, uploaded images, cached generated media, or audit artifacts, declare retention in `alchemy.run.ts`: archive logs after 60 days, delete exports after a year, and abort stale uploads after 7 days. |

## Validation

- `bun run check:affected`
- pre-commit hooks: `oxfmt check`, `oxlint`, `lintcn`, `typecheck`
- pre-push hook: affected quality checks
