### PR TITLE
fix(core): decouple auth copy from passkey UX

### DIFF
--- a/packages/coffee/core/src/application/CurrentActor.ts
+++ b/packages/coffee/core/src/application/CurrentActor.ts
@@ -64,7 +64,7 @@ function isStaffActor(actor: AppActor): actor is AuthenticatedActor {
 
 const authenticationRequiredError = () =>
   new AuthenticationRequiredError({
-    message: "Sign in with a passkey to place and view orders.",
+    message: "Sign in to place and view orders.",
   });
 
 const staffRoleRequiredError = () =>


### PR DESCRIPTION
## Summary
- Make the core authentication-required message provider-neutral
- Keep passkey-specific wording at the UI/auth edge instead of in coffee-core

## Verification
- `bun --filter @effect-coffee-shop/coffee-core test`
- `bun --filter @effect-coffee-shop/coffee-core typecheck`
- `bun --filter @effect-coffee-shop/coffee-core lint`
- Focused search found no Better Auth/passkey references in `coffee-core` or non-auth backend composition paths

## Known unrelated issue
- Full workspace typecheck, pre-commit hook, and push hook currently fail in `apps/backend/test/support/D1Miniflare.ts` because `@effect/sql-d1` is not resolvable there. This PR is a one-line core copy change and the targeted core checks pass.