### PR TITLE
refactor(ui): Redesign coffee shop UI

### DIFF
--- a/apps/ui/.oxlintrc.json
+++ b/apps/ui/.oxlintrc.json
@@ -21,21 +21,41 @@
     "typescript/no-unsafe-return": "error",
     "typescript/no-unsafe-type-assertion": "error",
     "typescript/no-unnecessary-type-assertion": "error",
+    "no-restricted-imports": [
+      "error",
+      {
+        "paths": [
+          {
+            "name": "react",
+            "importNames": ["useEffect"],
+            "message": "useEffect is banned in the UI workspace. Model effects at the boundary or use event/query state instead."
+          }
+        ]
+      }
+    ],
+    "no-restricted-properties": [
+      "error",
+      {
+        "object": "React",
+        "property": "useEffect",
+        "message": "useEffect is banned in the UI workspace."
+      }
+    ],
     "promise-function-async": "error"
   },
   "overrides": [
     {
       "files": ["src/**/*.{ts,tsx}", "vite.config.ts"],
       "rules": {
-        "complexity": ["error", { "max": 8 }],
-        "max-depth": ["error", { "max": 4 }],
-        "max-lines": ["error", { "max": 220, "skipBlankLines": true, "skipComments": true }],
+        "complexity": ["error", { "max": 6 }],
+        "max-depth": ["error", { "max": 3 }],
+        "max-lines": ["error", { "max": 180, "skipBlankLines": true, "skipComments": true }],
         "max-lines-per-function": [
           "error",
-          { "max": 60, "skipBlankLines": true, "skipComments": true }
+          { "max": 45, "skipBlankLines": true, "skipComments": true }
         ],
         "max-params": ["error", { "max": 4 }],
-        "max-statements": ["error", { "max": 16 }],
+        "max-statements": ["error", { "max": 12 }],
         "react/jsx-key": "error"
       }
     }

--- a/apps/ui/.storybook/StorybookShell.tsx
+++ b/apps/ui/.storybook/StorybookShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect, type PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 import { AppProviders } from "#app/AppProviders.tsx";
 import type { ThemePreference } from "#shared/hooks/useThemePreference.ts";
 
@@ -7,9 +7,7 @@ interface StorybookShellProps extends PropsWithChildren {
 }
 
 export function StorybookShell({ children, theme }: StorybookShellProps) {
-  useEffect(() => {
-    document.documentElement.classList.toggle("dark", theme === "dark");
-  }, [theme]);
+  document.documentElement.classList.toggle("dark", theme === "dark");
 
   return (
     <AppProviders>

--- a/apps/ui/src/app/NotFoundPage.tsx
+++ b/apps/ui/src/app/NotFoundPage.tsx
@@ -6,10 +6,10 @@ import { appRoutes } from "#app/routes.ts";
 export function NotFoundPage() {
   return (
     <main className="mx-auto grid min-h-screen w-full max-w-3xl place-items-center px-4 py-6">
-      <Card className="w-full border-border bg-card">
+      <Card className="w-full bg-card">
         <Card.Content className="grid gap-4 p-6 text-center">
-          <Text as="h1" className="text-4xl leading-none">
-            Route not found
+          <Text as="h1" className="text-3xl font-semibold leading-tight">
+            Page not found
           </Text>
           <Text as="p" className="text-muted-foreground">
             Head back to Beanline or jump into the customer or staff workspace.

--- a/apps/ui/src/features/assistant/components/AssistantComposer.tsx
+++ b/apps/ui/src/features/assistant/components/AssistantComposer.tsx
@@ -28,7 +28,7 @@ export function AssistantComposer(inputProps: AssistantComposerProps) {
   }
 
   return (
-    <div className="grid gap-3 border-t-2 border-border pt-4">
+    <div className="grid gap-3 border-t border-border pt-4">
       <Textarea
         className="min-h-32 max-h-56 bg-background"
         placeholder="Ask about the menu, place an order, or triage the queue."
@@ -37,21 +37,55 @@ export function AssistantComposer(inputProps: AssistantComposerProps) {
         onKeyDown={handleKeyDown}
       />
       <div className="flex flex-wrap items-center justify-between gap-3">
-        <div className="grid gap-2">
-          {isBusy ? (
-            <div className="flex items-center gap-2 text-sm font-medium">
-              <Spinner size="sm" />
-              <span>{busyDetail ?? "Waiting on Workers AI…"}</span>
-            </div>
-          ) : null}
-          <p className="text-sm text-muted-foreground">
-            {helpText ?? "Cmd/Ctrl + Enter sends the prompt to the Cloudflare Worker."}
-          </p>
-        </div>
-        <Button disabled={isBusy || input.trim() === ""} onClick={onSubmit}>
-          {isBusy ? "Calling live tools…" : (submitLabel ?? "Send")}
-        </Button>
+        <ComposerStatus busyDetail={busyDetail} helpText={helpText} isBusy={isBusy} />
+        <ComposerSubmitButton
+          input={input}
+          isBusy={isBusy}
+          submitLabel={submitLabel}
+          onSubmit={onSubmit}
+        />
       </div>
     </div>
+  );
+}
+
+interface ComposerStatusProps {
+  busyDetail: string | undefined;
+  helpText: string | undefined;
+  isBusy: boolean;
+}
+
+function ComposerStatus(inputProps: ComposerStatusProps) {
+  const { busyDetail, helpText, isBusy } = inputProps;
+
+  return (
+    <div className="grid gap-2">
+      {isBusy ? (
+        <div className="flex items-center gap-2 text-sm font-medium">
+          <Spinner size="sm" />
+          <span>{busyDetail ?? "Waiting on Workers AI…"}</span>
+        </div>
+      ) : null}
+      <p className="text-sm text-muted-foreground">
+        {helpText ?? "Cmd/Ctrl + Enter sends the prompt to the Cloudflare Worker."}
+      </p>
+    </div>
+  );
+}
+
+interface ComposerSubmitButtonProps {
+  input: string;
+  isBusy: boolean;
+  submitLabel: string | undefined;
+  onSubmit: () => void;
+}
+
+function ComposerSubmitButton(inputProps: ComposerSubmitButtonProps) {
+  const { input, isBusy, onSubmit, submitLabel } = inputProps;
+
+  return (
+    <Button disabled={isBusy || input.trim() === ""} onClick={onSubmit}>
+      {isBusy ? "Calling live tools…" : (submitLabel ?? "Send")}
+    </Button>
   );
 }

--- a/apps/ui/src/features/assistant/components/AssistantLandingView.tsx
+++ b/apps/ui/src/features/assistant/components/AssistantLandingView.tsx
@@ -9,8 +9,6 @@ import type {
 } from "#features/assistant/lib/assistant-chat.ts";
 import type { ConnectionStatus } from "@tanstack/ai-client";
 import { ThemeToggle } from "#shared/ui/ThemeToggle.tsx";
-import { Badge } from "#shared/ui/retroui/Badge.tsx";
-import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Card } from "#shared/ui/retroui/Card.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
 
@@ -50,102 +48,87 @@ export function AssistantLandingView(inputProps: AssistantLandingViewProps) {
   } = inputProps;
 
   return (
-    <main className="mx-auto grid min-h-screen w-full max-w-7xl gap-5 px-4 py-4 lg:px-6">
-      <section className="grid gap-5 xl:grid-cols-[1.2fr_0.8fr]">
-        <LandingHero theme={theme} onToggleTheme={onToggleTheme} />
-        <LandingFactsCard />
-      </section>
-      <section className="grid gap-5">
-        <AssistantTranscript
-          activityControl={<ToolActivityDrawer events={events} />}
-          connectionStatus={connectionStatus}
-          errorMessage={errorMessage}
-          input={input}
-          isBusy={isBusy}
-          latestActivity={events.length === 0 ? null : (events[events.length - 1] ?? null)}
-          messages={messages}
-          prompts={prompts}
-          status={status}
-          onInputChange={onInputChange}
-          onPromptClick={onPromptClick}
-          onReset={onReset}
-          onSubmit={onSubmit}
-        />
-      </section>
+    <main className="mx-auto flex min-h-screen w-full max-w-7xl flex-col gap-6 px-4 py-5 lg:px-6">
+      <AssistantShell theme={theme} onToggleTheme={onToggleTheme} />
+      <AssistantHeader status={status} />
+      <AssistantTranscript
+        activityControl={<ToolActivityDrawer events={events} />}
+        connectionStatus={connectionStatus}
+        errorMessage={errorMessage}
+        input={input}
+        isBusy={isBusy}
+        latestActivity={events.length === 0 ? null : (events[events.length - 1] ?? null)}
+        messages={messages}
+        prompts={prompts}
+        status={status}
+        onInputChange={onInputChange}
+        onPromptClick={onPromptClick}
+        onReset={onReset}
+        onSubmit={onSubmit}
+      />
     </main>
   );
 }
 
-interface LandingHeroProps {
+interface AssistantShellProps {
   onToggleTheme: () => void;
   theme: ThemePreference;
 }
 
-function LandingHero({ onToggleTheme, theme }: LandingHeroProps) {
+function AssistantShell({ onToggleTheme, theme }: AssistantShellProps) {
   return (
-    <Card className="w-full border-border bg-primary text-primary-foreground">
-      <Card.Content className="grid gap-5 p-5 lg:p-6">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div className="flex flex-wrap gap-2">
-            <Badge className="rounded-none bg-black px-2.5 py-1 text-white" size="sm">
-              Cloudflare Workers AI
-            </Badge>
-            <Badge className="rounded-none px-2.5 py-1" size="sm" variant="outline">
-              D1-backed coffee tools
-            </Badge>
-          </div>
-          <ThemeToggle theme={theme} onToggle={onToggleTheme} />
-        </div>
-        <div className="grid gap-3">
-          <Text as="h1" className="max-w-4xl text-4xl leading-none md:text-6xl">
-            Beanline Control Surface
-          </Text>
-          <Text as="p" className="max-w-3xl text-base text-primary-foreground/80 md:text-lg">
-            The landing assistant now runs through your same-origin Cloudflare Worker, executes
-            coffee tools server-side, and shares the same live state as the customer and staff
-            workspaces.
-          </Text>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <Button asChild variant="secondary">
-            <a href={appRoutes.shop}>Open customer workspace</a>
-          </Button>
-          <Button asChild variant="outline">
-            <a href={appRoutes.staff}>Open staff workspace</a>
-          </Button>
-        </div>
-      </Card.Content>
-    </Card>
+    <header className="flex min-h-14 items-center justify-between border-b border-border pb-4">
+      <Text as="p" className="text-lg font-semibold">
+        Beanline
+      </Text>
+      <nav className="hidden items-center gap-6 text-sm text-muted-foreground md:flex">
+        <a className="font-medium text-foreground" href={appRoutes.home}>
+          Assistant
+        </a>
+        <a href={appRoutes.shop}>Order</a>
+        <a href={appRoutes.staff}>Staff</a>
+      </nav>
+      <ThemeToggle compact theme={theme} onToggle={onToggleTheme} />
+    </header>
   );
 }
 
-function LandingFactsCard() {
+function AssistantHeader({ status }: Pick<AssistantLandingViewProps, "status">) {
   return (
-    <Card className="w-full border-border bg-card">
-      <Card.Content className="grid gap-4 p-5">
-        <MetricStrip label="Assistant runtime" value="Workers AI via same-origin Worker" />
-        <MetricStrip label="Tool orchestration" value="TanStack AI server tools + SSE stream" />
-        <MetricStrip label="Coffee state" value="Shared D1 database for orders and queue" />
-        <MetricStrip label="Deployment shape" value="Static UI + Worker + D1 on Cloudflare" />
-      </Card.Content>
-    </Card>
+    <section className="flex flex-wrap items-end justify-between gap-4">
+      <div className="grid gap-2">
+        <Text as="h1" className="text-3xl font-semibold leading-tight md:text-4xl">
+          Assistant
+        </Text>
+        <Text as="p" className="max-w-2xl text-sm text-muted-foreground md:text-base">
+          Ask about menu, orders, or queue status.
+        </Text>
+      </div>
+      <Card className="w-full md:w-auto">
+        <Card.Content className="flex flex-wrap gap-5 p-4">
+          <MetricStrip label="Runtime" value={status.phase === "running" ? "Busy" : "Ready"} />
+          <MetricStrip label="Tools" value="Server" />
+          <MetricStrip label="State" value="Shared" />
+        </Card.Content>
+      </Card>
+    </section>
+  );
+}
+
+function MetricStrip({ label, value }: MetricStripProps) {
+  return (
+    <div className="grid min-w-20 gap-1">
+      <Text as="p" className="text-xs text-muted-foreground">
+        {label}
+      </Text>
+      <Text as="p" className="text-xl font-semibold">
+        {value}
+      </Text>
+    </div>
   );
 }
 
 interface MetricStripProps {
   label: string;
   value: string;
-}
-
-function MetricStrip({ label, value }: MetricStripProps) {
-  return (
-    <div className="grid gap-2 border-b-2 border-dashed border-border pb-3 last:border-b-0 last:pb-0">
-      <Text as="p" className="text-xs uppercase tracking-[0.08em] text-muted-foreground">
-        {label}
-      </Text>
-      <Text as="h3" className="text-xl leading-snug">
-        {value}
-      </Text>
-    </div>
-  );
 }

--- a/apps/ui/src/features/assistant/components/AssistantStatusPanel.tsx
+++ b/apps/ui/src/features/assistant/components/AssistantStatusPanel.tsx
@@ -1,5 +1,4 @@
 import type { ConnectionStatus } from "@tanstack/ai-client";
-import { Badge } from "#shared/ui/retroui/Badge.tsx";
 import { Spinner } from "#shared/ui/retroui/Spinner.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
 import type { AssistantStatus } from "#features/assistant/lib/assistant-chat.ts";
@@ -14,37 +13,34 @@ export function AssistantStatusPanel(inputProps: AssistantStatusPanelProps) {
   const { connectionStatus, isBusy, status } = inputProps;
 
   return (
-    <div className="grid gap-3 border-2 border-border bg-background p-4">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="grid gap-2">
-          <div className="flex items-center gap-2">
-            {isBusy ? <Spinner size="sm" /> : null}
-            <Text as="p" className="text-sm font-semibold uppercase tracking-[0.08em]">
-              {status.label}
-            </Text>
-          </div>
-          <Text as="p" className="max-w-2xl text-sm text-muted-foreground">
-            {status.detail}
-          </Text>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Badge className="rounded-none px-2.5 py-1" size="sm" variant="surface">
-            Workers AI
-          </Badge>
-          <Badge className="rounded-none px-2.5 py-1" size="sm" variant="outline">
-            Server tools
-          </Badge>
-          <Badge
-            className="rounded-none px-2.5 py-1"
-            size="sm"
-            variant={connectionBadgeVariant[connectionStatus]}
-          >
-            {connectionBadgeLabel[connectionStatus]}
-          </Badge>
-        </div>
+    <div className="grid gap-3 rounded-md border border-border bg-background p-4">
+      <div className="flex items-center gap-2">
+        {isBusy ? <Spinner size="sm" /> : null}
+        <Text as="h3" className="text-base font-semibold">
+          {status.label}
+        </Text>
       </div>
+      <Text as="p" className="text-sm text-muted-foreground">
+        {status.detail}
+      </Text>
+      <StatusLine label="Connection" value={connectionBadgeLabel[connectionStatus]} />
+      <StatusLine label="Tools" value="Server-side" />
     </div>
   );
+}
+
+function StatusLine({ label, value }: StatusLineProps) {
+  return (
+    <div className="flex items-center justify-between gap-3 text-sm">
+      <span className="text-muted-foreground">{label}</span>
+      <span className="font-medium">{value}</span>
+    </div>
+  );
+}
+
+interface StatusLineProps {
+  label: string;
+  value: string;
 }
 
 const connectionBadgeLabel = {
@@ -52,11 +48,4 @@ const connectionBadgeLabel = {
   connecting: "Connecting",
   disconnected: "Idle",
   error: "Connection error",
-} as const;
-
-const connectionBadgeVariant = {
-  connected: "surface",
-  connecting: "outline",
-  disconnected: "outline",
-  error: "solid",
 } as const;

--- a/apps/ui/src/features/assistant/components/AssistantTranscript.tsx
+++ b/apps/ui/src/features/assistant/components/AssistantTranscript.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useRef, type ReactNode, type RefObject } from "react";
+import type { ReactNode } from "react";
 import { Alert } from "#shared/ui/retroui/Alert.tsx";
 import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Card } from "#shared/ui/retroui/Card.tsx";
 import { AssistantComposer } from "#features/assistant/components/AssistantComposer.tsx";
 import { AssistantStatusPanel } from "#features/assistant/components/AssistantStatusPanel.tsx";
+import { TranscriptViewport } from "#features/assistant/components/TranscriptViewport.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
 import type {
   AssistantDisplayMessage,
@@ -29,56 +30,56 @@ interface AssistantTranscriptProps {
 }
 
 export function AssistantTranscript(inputProps: AssistantTranscriptProps) {
-  const {
-    activityControl,
-    connectionStatus,
-    errorMessage,
-    input,
-    isBusy,
-    latestActivity,
-    messages,
-    onInputChange,
-    onPromptClick,
-    onReset,
-    onSubmit,
-    prompts,
-    status,
-  } = inputProps;
-  const transcriptViewportRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    const viewport = transcriptViewportRef.current;
-    if (viewport === null) {
-      return;
-    }
-
-    viewport.scrollTop = viewport.scrollHeight;
-  }, [isBusy, messages.length]);
+  const props = inputProps;
 
   return (
-    <Card className="w-full border-border bg-card">
-      <Card.Content className="grid gap-4 p-5">
+    <section className="grid flex-1 gap-4 xl:grid-cols-[minmax(0,1fr)_22rem]">
+      <ConversationPanel {...props} />
+      <AssistantRail {...props} />
+    </section>
+  );
+}
+
+function ConversationPanel(inputProps: AssistantTranscriptProps) {
+  const { activityControl, errorMessage, messages, onReset } = inputProps;
+
+  return (
+    <Card className="min-h-[34rem] w-full">
+      <Card.Content className="flex h-full flex-col gap-4 p-4">
         <TranscriptHeader activityControl={activityControl} onReset={onReset} />
-        <AssistantStatusPanel connectionStatus={connectionStatus} isBusy={isBusy} status={status} />
-        {errorMessage !== null ? (
-          <Alert status="warning">
-            <Alert.Title>Assistant warning</Alert.Title>
-            <Alert.Description>{errorMessage}</Alert.Description>
-          </Alert>
-        ) : null}
-        <PromptStrip prompts={prompts} onPromptClick={onPromptClick} />
-        <TranscriptViewport messages={messages} viewportRef={transcriptViewportRef} />
-        <AssistantComposer
-          {...getBusyDetailProp(status, latestActivity)}
-          helpText="Cmd/Ctrl + Enter sends the prompt to the same-origin Worker."
-          input={input}
-          isBusy={isBusy}
-          submitLabel={isBusy ? "Calling live tools…" : "Send"}
-          onInputChange={onInputChange}
-          onSubmit={onSubmit}
-        />
+        <AssistantWarning message={errorMessage} />
+        <TranscriptViewport messages={messages} />
+        <ComposerSlot {...inputProps} />
       </Card.Content>
     </Card>
+  );
+}
+
+function AssistantRail(inputProps: AssistantTranscriptProps) {
+  const { connectionStatus, isBusy, onPromptClick, prompts, status } = inputProps;
+
+  return (
+    <Card className="w-full">
+      <Card.Content className="grid gap-4 p-4">
+        <AssistantStatusPanel connectionStatus={connectionStatus} isBusy={isBusy} status={status} />
+        <PromptStrip prompts={prompts} onPromptClick={onPromptClick} />
+      </Card.Content>
+    </Card>
+  );
+}
+
+function ComposerSlot(inputProps: AssistantTranscriptProps) {
+  const { input, isBusy, latestActivity, onInputChange, onSubmit, status } = inputProps;
+
+  return (
+    <AssistantComposer
+      {...getBusyDetailProp(status, latestActivity)}
+      input={input}
+      isBusy={isBusy}
+      submitLabel={isBusy ? "Calling live tools..." : "Send"}
+      onInputChange={onInputChange}
+      onSubmit={onSubmit}
+    />
   );
 }
 
@@ -105,16 +106,20 @@ function getBusyDetailProp(
   return busyDetail === undefined ? {} : { busyDetail };
 }
 
-interface PromptStripProps {
-  onPromptClick: (prompt: string) => void;
-  prompts: readonly string[];
-}
-
 function PromptStrip({ onPromptClick, prompts }: PromptStripProps) {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="grid gap-2">
+      <Text as="h3" className="text-base font-semibold">
+        Suggested
+      </Text>
       {prompts.map((prompt) => (
-        <Button key={prompt} size="sm" variant="outline" onClick={() => onPromptClick(prompt)}>
+        <Button
+          key={prompt}
+          className="h-auto min-h-9 justify-start whitespace-normal py-2 text-left leading-snug"
+          size="sm"
+          variant="outline"
+          onClick={() => onPromptClick(prompt)}
+        >
           {prompt}
         </Button>
       ))}
@@ -122,24 +127,23 @@ function PromptStrip({ onPromptClick, prompts }: PromptStripProps) {
   );
 }
 
-interface TranscriptViewportProps {
-  messages: readonly AssistantDisplayMessage[];
-  viewportRef: RefObject<HTMLDivElement | null>;
+interface PromptStripProps {
+  onPromptClick: (prompt: string) => void;
+  prompts: readonly string[];
 }
 
-function TranscriptViewport({ messages, viewportRef }: TranscriptViewportProps) {
+function TranscriptHeader({ activityControl, onReset }: TranscriptHeaderProps) {
   return (
-    <div
-      ref={viewportRef}
-      className="grid min-h-80 max-h-[32rem] gap-3 overflow-y-auto border-2 border-border bg-background p-4 pr-3"
-    >
-      {messages.length === 0 ? (
-        <EmptyTranscript />
-      ) : (
-        messages.map((message) => (
-          <TranscriptBubble key={message.id} content={message.content} speaker={message.role} />
-        ))
-      )}
+    <div className="flex flex-wrap items-center justify-between gap-3">
+      <Text as="h2" className="text-xl font-semibold leading-tight">
+        Conversation
+      </Text>
+      <div className="flex flex-wrap gap-3">
+        {activityControl}
+        <Button variant="outline" onClick={onReset}>
+          Clear
+        </Button>
+      </div>
     </div>
   );
 }
@@ -149,63 +153,11 @@ interface TranscriptHeaderProps {
   onReset: () => void;
 }
 
-function TranscriptHeader({ activityControl, onReset }: TranscriptHeaderProps) {
-  return (
-    <div className="grid gap-4 md:grid-cols-[minmax(0,1fr)_auto] md:items-start">
-      <div className="grid gap-2">
-        <Text as="h2" className="text-3xl leading-none md:text-4xl">
-          Chat with Beanline over Workers AI.
-        </Text>
-        <Text as="p" className="max-w-3xl text-sm text-muted-foreground md:text-base">
-          The assistant runs through your Cloudflare Worker, calls coffee tools server-side, and
-          shares the same D1-backed state as the customer and staff workspaces.
-        </Text>
-      </div>
-      <div className="flex flex-wrap gap-3">
-        {activityControl}
-        <Button variant="outline" onClick={onReset}>
-          Clear transcript
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function EmptyTranscript() {
-  return (
-    <div className="grid content-center gap-3 text-center">
-      <Text as="h3" className="text-2xl leading-none">
-        No messages yet.
-      </Text>
-      <Text as="p" className="mx-auto max-w-xl text-sm text-muted-foreground">
-        Ask Beanline to list the menu, place an order, inspect the queue, or explain what just
-        changed in the coffee shop.
-      </Text>
-    </div>
-  );
-}
-
-interface TranscriptBubbleProps {
-  content: string;
-  speaker: AssistantDisplayMessage["role"];
-}
-
-function TranscriptBubble({ content, speaker }: TranscriptBubbleProps) {
-  const bubbleTone =
-    speaker === "assistant"
-      ? "border-border bg-card text-card-foreground"
-      : "border-black bg-primary text-primary-foreground";
-  const labelTone =
-    speaker === "assistant" ? "text-muted-foreground" : "text-primary-foreground/70";
-
-  return (
-    <div className={`ml-0 grid gap-2 border-2 p-3 shadow-sm ${bubbleTone}`}>
-      <Text as="p" className={`text-xs uppercase tracking-[0.08em] ${labelTone}`}>
-        {speaker === "assistant" ? "Beanline" : "You"}
-      </Text>
-      <Text as="p" className="font-sans text-sm leading-6 whitespace-pre-wrap">
-        {content}
-      </Text>
-    </div>
+function AssistantWarning({ message }: { message: string | null }) {
+  return message === null ? null : (
+    <Alert status="warning">
+      <Alert.Title>Assistant warning</Alert.Title>
+      <Alert.Description>{message}</Alert.Description>
+    </Alert>
   );
 }

--- a/apps/ui/src/features/assistant/components/TranscriptViewport.tsx
+++ b/apps/ui/src/features/assistant/components/TranscriptViewport.tsx
@@ -1,0 +1,54 @@
+import { Text } from "#shared/ui/retroui/Text.tsx";
+import type { AssistantDisplayMessage } from "#features/assistant/lib/assistant-chat.ts";
+
+interface TranscriptViewportProps {
+  messages: readonly AssistantDisplayMessage[];
+}
+
+export function TranscriptViewport({ messages }: TranscriptViewportProps) {
+  return (
+    <div className="grid min-h-80 flex-1 content-start gap-3 overflow-y-auto rounded-md border border-border bg-background p-4 pr-3">
+      {messages.length === 0 ? <EmptyTranscript /> : <TranscriptMessages messages={messages} />}
+    </div>
+  );
+}
+
+function TranscriptMessages({ messages }: TranscriptViewportProps) {
+  return messages.map((message) => (
+    <TranscriptBubble key={message.id} content={message.content} speaker={message.role} />
+  ));
+}
+
+function EmptyTranscript() {
+  return (
+    <div className="grid content-center gap-3 text-center">
+      <Text as="h3" className="text-xl font-semibold leading-tight">
+        No messages yet
+      </Text>
+      <Text as="p" className="mx-auto max-w-xl text-sm text-muted-foreground">
+        Ask Beanline to list the menu, place an order, or inspect the queue.
+      </Text>
+    </div>
+  );
+}
+
+function TranscriptBubble({ content, speaker }: TranscriptBubbleProps) {
+  const bubbleTone = speaker === "assistant" ? "bg-card" : "bg-primary text-primary-foreground";
+  const label = speaker === "assistant" ? "Beanline" : "You";
+
+  return (
+    <div className={`grid gap-2 rounded-md border border-border p-3 ${bubbleTone}`}>
+      <Text as="p" className="text-xs font-medium text-muted-foreground">
+        {label}
+      </Text>
+      <Text as="p" className="text-sm leading-6 whitespace-pre-wrap">
+        {content}
+      </Text>
+    </div>
+  );
+}
+
+interface TranscriptBubbleProps {
+  content: string;
+  speaker: AssistantDisplayMessage["role"];
+}

--- a/apps/ui/src/features/auth/components/AgentApprovalCards.tsx
+++ b/apps/ui/src/features/auth/components/AgentApprovalCards.tsx
@@ -67,48 +67,83 @@ export function PendingApprovalCard(inputProps: PendingApprovalCardProps) {
   }
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
         <Text as="h3">Approve agent access</Text>
         <Text as="p" className="text-sm text-muted-foreground">
           Review the pending delegated capabilities before authorizing this agent.
         </Text>
       </Card.Header>
       <Card.Content className="grid gap-5">
-        <div className="grid gap-1">
-          <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
-            Agent
-          </Text>
-          <Text as="h4">{approval.agent_name ?? approval.agent_id ?? "Unknown agent"}</Text>
-          <Text as="p" className="text-sm text-muted-foreground">
-            Device code expires in {formatExpiresIn(approval.expires_in)}.
-          </Text>
-        </div>
-        {approval.binding_message !== null ? (
-          <Alert className="border-border bg-card" status="info">
-            <Alert.Title>Binding message</Alert.Title>
-            <Alert.Description>{approval.binding_message}</Alert.Description>
-          </Alert>
-        ) : null}
-        <div className="grid gap-2">
-          <Text as="h5">Requested capabilities</Text>
-          <ul className="grid gap-2">
-            {approval.capabilities.map((capability) => (
-              <li key={capability} className="border-2 border-border bg-card px-3 py-2 text-sm">
-                {capability}
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <Button disabled={actionPending} onClick={handleApprove}>
-            Approve capabilities
-          </Button>
-          <Button disabled={actionPending} variant="outline" onClick={handleDeny}>
-            Deny request
-          </Button>
-        </div>
+        <ApprovalIdentity approval={approval} />
+        <BindingMessage message={approval.binding_message} />
+        <CapabilityList capabilities={approval.capabilities} />
+        <ApprovalActions
+          actionPending={actionPending}
+          onApprove={handleApprove}
+          onDeny={handleDeny}
+        />
       </Card.Content>
     </Card>
+  );
+}
+
+function ApprovalIdentity({ approval }: { approval: PendingAgentApproval }) {
+  return (
+    <div className="grid gap-1">
+      <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        Agent
+      </Text>
+      <Text as="h4">{approval.agent_name ?? approval.agent_id ?? "Unknown agent"}</Text>
+      <Text as="p" className="text-sm text-muted-foreground">
+        Device code expires in {formatExpiresIn(approval.expires_in)}.
+      </Text>
+    </div>
+  );
+}
+
+function BindingMessage({ message }: { message: string | null }) {
+  return message !== null ? (
+    <Alert className="border-border bg-background" status="info">
+      <Alert.Title>Binding message</Alert.Title>
+      <Alert.Description>{message}</Alert.Description>
+    </Alert>
+  ) : null;
+}
+
+function CapabilityList({ capabilities }: { capabilities: readonly string[] }) {
+  return (
+    <div className="grid gap-2">
+      <Text as="h5">Requested capabilities</Text>
+      <ul className="grid gap-2">
+        {capabilities.map((capability) => (
+          <li
+            key={capability}
+            className="rounded-md border border-border bg-background px-3 py-2 text-sm"
+          >
+            {capability}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function ApprovalActions(inputProps: {
+  actionPending: boolean;
+  onApprove: () => Promise<void>;
+  onDeny: () => Promise<void>;
+}) {
+  const { actionPending, onApprove, onDeny } = inputProps;
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button disabled={actionPending} onClick={() => void onApprove()}>
+        Approve capabilities
+      </Button>
+      <Button disabled={actionPending} variant="outline" onClick={() => void onDeny()}>
+        Deny request
+      </Button>
+    </div>
   );
 }

--- a/apps/ui/src/features/auth/components/AgentApprovalPageBody.tsx
+++ b/apps/ui/src/features/auth/components/AgentApprovalPageBody.tsx
@@ -1,9 +1,10 @@
 import { appRoutes } from "#app/routes.ts";
 import {
-  AgentApprovalErrorCard,
-  PendingApprovalCard,
-  ResolutionCard,
-} from "#features/auth/components/AgentApprovalCards.tsx";
+  ApprovalErrorState,
+  MissingRequestState,
+  PendingRequestState,
+  ResolutionState,
+} from "#features/auth/components/AgentApprovalStates.tsx";
 import { PasskeyGateCard } from "#features/auth/components/PasskeyGateCard.tsx";
 import { SessionCard } from "#features/auth/components/SessionCard.tsx";
 import type { PendingAgentApproval } from "#features/auth/api/agent-approvals.ts";
@@ -13,6 +14,11 @@ import type { ResolutionStatus } from "#features/auth/hooks/useAgentApprovalPage
 import type { ThemePreference } from "#shared/hooks/useThemePreference.ts";
 import { Card } from "#shared/ui/retroui/Card.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
+
+const approvalNavLinks = [
+  { href: appRoutes.home, label: "Assistant", variant: "outline" as const },
+  { href: appRoutes.shop, label: "Customer workspace", variant: "outline" as const },
+];
 
 export interface AgentApprovalPageBodyProps {
   approvalError: string | null;
@@ -59,87 +65,46 @@ function AgentApprovalIntro({
   );
 }
 
-function ApprovalErrorState({
-  approvalError,
-  routeError,
-}: Pick<AgentApprovalPageBodyProps, "approvalError" | "routeError">) {
-  return approvalError === null ? null : (
-    <AgentApprovalErrorCard
-      message={approvalError}
-      title={routeError === null ? "Approval is unavailable" : "Invalid approval link"}
-    />
-  );
-}
-
-function ResolutionState({
-  resolutionStatus,
-}: Pick<AgentApprovalPageBodyProps, "resolutionStatus">) {
-  return resolutionStatus === null ? null : <ResolutionCard status={resolutionStatus} />;
-}
-
-function MissingRequestState({
-  pendingApproval,
-  resolutionStatus,
-  routeError,
-  signedInViewer,
-}: Pick<
-  AgentApprovalPageBodyProps,
-  "pendingApproval" | "resolutionStatus" | "routeError" | "signedInViewer"
->) {
-  const pendingRequestMissing =
-    signedInViewer !== null &&
-    routeError === null &&
-    resolutionStatus === null &&
-    pendingApproval === null;
-
-  return pendingRequestMissing ? (
-    <AgentApprovalErrorCard
-      message="This delegated request is no longer pending for your account."
-      title="Request not found"
-    />
-  ) : null;
-}
-
-function PendingRequestState({
-  pendingApproval,
-  resolutionMutation,
-  resolutionStatus,
-  resolvePendingApproval,
-  routeError,
-  signedInViewer,
-}: Pick<
-  AgentApprovalPageBodyProps,
-  | "pendingApproval"
-  | "resolutionMutation"
-  | "resolutionStatus"
-  | "resolvePendingApproval"
-  | "routeError"
-  | "signedInViewer"
->) {
-  if (
-    signedInViewer === null ||
-    routeError !== null ||
-    resolutionStatus !== null ||
-    pendingApproval === null
-  ) {
-    return null;
-  }
-
-  async function approveRequest(): Promise<void> {
-    await resolvePendingApproval("approve");
-  }
-
-  async function denyRequest(): Promise<void> {
-    await resolvePendingApproval("deny");
-  }
+function AgentApprovalPanel(inputProps: Omit<AgentApprovalPageBodyProps, "theme" | "toggleTheme">) {
+  const {
+    approvalError,
+    auth,
+    pendingApproval,
+    resolutionMutation,
+    resolutionStatus,
+    resolvePendingApproval,
+    routeError,
+    signedInViewer,
+  } = inputProps;
 
   return (
-    <PendingApprovalCard
-      actionPending={resolutionMutation.isPending}
-      approval={pendingApproval}
-      onApprove={approveRequest}
-      onDeny={denyRequest}
-    />
+    <Card className="mx-auto w-full max-w-2xl">
+      <Card.Header className="border-b border-border">
+        <Text as="h3">Authorize agent</Text>
+        <Text as="p" className="text-sm text-muted-foreground">
+          Review delegated capabilities before approving this device.
+        </Text>
+      </Card.Header>
+      <Card.Content className="grid gap-5">
+        <AgentApprovalIntro auth={auth} signedInViewer={signedInViewer} />
+        <ApprovalErrorState approvalError={approvalError} routeError={routeError} />
+        <ResolutionState resolutionStatus={resolutionStatus} />
+        <MissingRequestState
+          pendingApproval={pendingApproval}
+          resolutionStatus={resolutionStatus}
+          routeError={routeError}
+          signedInViewer={signedInViewer}
+        />
+        <PendingRequestState
+          pendingApproval={pendingApproval}
+          resolutionMutation={resolutionMutation}
+          resolutionStatus={resolutionStatus}
+          resolvePendingApproval={resolvePendingApproval}
+          routeError={routeError}
+          signedInViewer={signedInViewer}
+        />
+      </Card.Content>
+    </Card>
   );
 }
 
@@ -158,47 +123,27 @@ export function AgentApprovalPageBody(inputProps: AgentApprovalPageBodyProps) {
   } = inputProps;
 
   return (
-    <main className="mx-auto grid min-h-screen w-full max-w-5xl gap-5 px-4 py-4 lg:px-6">
+    <main className="mx-auto grid min-h-screen w-full max-w-5xl gap-5 px-4 py-5 lg:px-6">
       <PageHeader
         activeOrders={0}
         badgeLabel="Agent approval"
         footerLabel="Delegated Better Auth capability review"
-        navLinks={[
-          { href: appRoutes.home, label: "Assistant", variant: "outline" as const },
-          { href: appRoutes.shop, label: "Customer workspace", variant: "outline" as const },
-        ]}
+        navLinks={approvalNavLinks}
         theme={theme}
         title="Approve agent capabilities"
         totalOrders={0}
         onToggleTheme={toggleTheme}
       />
-      <Card className="w-full border-border">
-        <Card.Header className="border-b-2 border-border bg-card">
-          <Text as="h3">Device authorization</Text>
-          <Text as="p" className="text-sm text-muted-foreground">
-            Sign in with the passkey-linked account that should authorize this delegated agent.
-          </Text>
-        </Card.Header>
-        <Card.Content className="grid gap-5">
-          <AgentApprovalIntro auth={auth} signedInViewer={signedInViewer} />
-          <ApprovalErrorState approvalError={approvalError} routeError={routeError} />
-          <ResolutionState resolutionStatus={resolutionStatus} />
-          <MissingRequestState
-            pendingApproval={pendingApproval}
-            resolutionStatus={resolutionStatus}
-            routeError={routeError}
-            signedInViewer={signedInViewer}
-          />
-          <PendingRequestState
-            pendingApproval={pendingApproval}
-            resolutionMutation={resolutionMutation}
-            resolutionStatus={resolutionStatus}
-            resolvePendingApproval={resolvePendingApproval}
-            routeError={routeError}
-            signedInViewer={signedInViewer}
-          />
-        </Card.Content>
-      </Card>
+      <AgentApprovalPanel
+        approvalError={approvalError}
+        auth={auth}
+        pendingApproval={pendingApproval}
+        resolutionMutation={resolutionMutation}
+        resolutionStatus={resolutionStatus}
+        resolvePendingApproval={resolvePendingApproval}
+        routeError={routeError}
+        signedInViewer={signedInViewer}
+      />
     </main>
   );
 }

--- a/apps/ui/src/features/auth/components/AgentApprovalStates.tsx
+++ b/apps/ui/src/features/auth/components/AgentApprovalStates.tsx
@@ -1,0 +1,77 @@
+import {
+  AgentApprovalErrorCard,
+  PendingApprovalCard,
+  ResolutionCard,
+} from "#features/auth/components/AgentApprovalCards.tsx";
+import type { AgentApprovalPageBodyProps } from "#features/auth/components/AgentApprovalPageBody.tsx";
+
+export function ApprovalErrorState({
+  approvalError,
+  routeError,
+}: Pick<AgentApprovalPageBodyProps, "approvalError" | "routeError">) {
+  return approvalError === null ? null : (
+    <AgentApprovalErrorCard
+      message={approvalError}
+      title={routeError === null ? "Approval is unavailable" : "Invalid approval link"}
+    />
+  );
+}
+
+export function ResolutionState({
+  resolutionStatus,
+}: Pick<AgentApprovalPageBodyProps, "resolutionStatus">) {
+  return resolutionStatus === null ? null : <ResolutionCard status={resolutionStatus} />;
+}
+
+export function MissingRequestState({
+  pendingApproval,
+  resolutionStatus,
+  routeError,
+  signedInViewer,
+}: Pick<
+  AgentApprovalPageBodyProps,
+  "pendingApproval" | "resolutionStatus" | "routeError" | "signedInViewer"
+>) {
+  const requestMissing =
+    signedInViewer !== null &&
+    routeError === null &&
+    resolutionStatus === null &&
+    pendingApproval === null;
+
+  return requestMissing ? (
+    <AgentApprovalErrorCard
+      message="This delegated request is no longer pending for your account."
+      title="Request not found"
+    />
+  ) : null;
+}
+
+export function PendingRequestState({
+  pendingApproval,
+  resolutionMutation,
+  resolutionStatus,
+  resolvePendingApproval,
+  routeError,
+  signedInViewer,
+}: Pick<
+  AgentApprovalPageBodyProps,
+  | "pendingApproval"
+  | "resolutionMutation"
+  | "resolutionStatus"
+  | "resolvePendingApproval"
+  | "routeError"
+  | "signedInViewer"
+>) {
+  if (signedInViewer === null || routeError !== null || resolutionStatus !== null) {
+    return null;
+  }
+
+  return pendingApproval === null ? null : (
+    <PendingApprovalCard
+      actionPending={resolutionMutation.isPending}
+      approval={pendingApproval}
+      onApprove={async () => resolvePendingApproval("approve")}
+      onDeny={async () => resolvePendingApproval("deny")}
+    />
+  );
+}

--- a/apps/ui/src/features/auth/components/PasskeyGateCard.tsx
+++ b/apps/ui/src/features/auth/components/PasskeyGateCard.tsx
@@ -28,6 +28,67 @@ function getPendingLabel(pendingAction: PasskeyGateCardProps["pendingAction"]): 
   }
 }
 
+function PasskeyNameField(
+  inputProps: Pick<PasskeyGateCardProps, "displayName" | "isPending" | "onDisplayNameChange">,
+) {
+  const { displayName, isPending, onDisplayNameChange } = inputProps;
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor="passkey-display-name">Name on your order</Label>
+      <Input
+        autoComplete="name"
+        disabled={isPending}
+        id="passkey-display-name"
+        placeholder="Taylor"
+        value={displayName}
+        onChange={(event) => onDisplayNameChange(event.target.value)}
+      />
+      <Text as="p" className="text-sm text-muted-foreground">
+        New customers register once, then come back with a single passkey tap.
+      </Text>
+    </div>
+  );
+}
+
+function PasskeyActions(
+  inputProps: Pick<PasskeyGateCardProps, "isPending" | "onCreateAccount" | "onSignIn">,
+) {
+  const { isPending, onCreateAccount, onSignIn } = inputProps;
+
+  return (
+    <div className="flex flex-wrap gap-3">
+      <Button disabled={isPending} onClick={() => void onCreateAccount()}>
+        Create account with passkey
+      </Button>
+      <Button disabled={isPending} variant="outline" onClick={() => void onSignIn()}>
+        Sign in with passkey
+      </Button>
+    </div>
+  );
+}
+
+function PendingPasskeyNotice({
+  isPending,
+  pendingAction,
+}: Pick<PasskeyGateCardProps, "isPending" | "pendingAction">) {
+  return isPending ? (
+    <Alert className="border-border bg-background" status="info">
+      <Alert.Title>{getPendingLabel(pendingAction)}</Alert.Title>
+      <Alert.Description>Use your device’s passkey prompt to continue.</Alert.Description>
+    </Alert>
+  ) : null;
+}
+
+function PasskeyError({ errorMessage }: Pick<PasskeyGateCardProps, "errorMessage">) {
+  return errorMessage !== null ? (
+    <Alert status="warning">
+      <Alert.Title>Could not complete passkey flow</Alert.Title>
+      <Alert.Description>{errorMessage}</Alert.Description>
+    </Alert>
+  ) : null;
+}
+
 export function PasskeyGateCard(inputProps: PasskeyGateCardProps) {
   const {
     displayName,
@@ -42,48 +103,26 @@ export function PasskeyGateCard(inputProps: PasskeyGateCardProps) {
   } = inputProps;
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
         <Text as="h3">{title}</Text>
         <Text as="p" className="text-sm text-muted-foreground">
           {description}
         </Text>
       </Card.Header>
       <Card.Content className="grid gap-5">
-        <div className="grid gap-2">
-          <Label htmlFor="passkey-display-name">Name on your order</Label>
-          <Input
-            autoComplete="name"
-            disabled={isPending}
-            id="passkey-display-name"
-            placeholder="Taylor"
-            value={displayName}
-            onChange={(event) => onDisplayNameChange(event.target.value)}
-          />
-          <Text as="p" className="text-sm text-muted-foreground">
-            New customers register once, then come back with a single passkey tap.
-          </Text>
-        </div>
-        <div className="flex flex-wrap gap-3">
-          <Button disabled={isPending} onClick={() => void onCreateAccount()}>
-            Create account with passkey
-          </Button>
-          <Button disabled={isPending} variant="outline" onClick={() => void onSignIn()}>
-            Sign in with passkey
-          </Button>
-        </div>
-        {isPending ? (
-          <Alert className="border-border bg-card" status="info">
-            <Alert.Title>{getPendingLabel(pendingAction)}</Alert.Title>
-            <Alert.Description>Use your device’s passkey prompt to continue.</Alert.Description>
-          </Alert>
-        ) : null}
-        {errorMessage !== null ? (
-          <Alert status="warning">
-            <Alert.Title>Could not complete passkey flow</Alert.Title>
-            <Alert.Description>{errorMessage}</Alert.Description>
-          </Alert>
-        ) : null}
+        <PasskeyNameField
+          displayName={displayName}
+          isPending={isPending}
+          onDisplayNameChange={onDisplayNameChange}
+        />
+        <PasskeyActions
+          isPending={isPending}
+          onCreateAccount={onCreateAccount}
+          onSignIn={onSignIn}
+        />
+        <PendingPasskeyNotice isPending={isPending} pendingAction={pendingAction} />
+        <PasskeyError errorMessage={errorMessage} />
       </Card.Content>
     </Card>
   );

--- a/apps/ui/src/features/auth/components/SessionCard.tsx
+++ b/apps/ui/src/features/auth/components/SessionCard.tsx
@@ -1,4 +1,3 @@
-import { Badge } from "#shared/ui/retroui/Badge.tsx";
 import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Card } from "#shared/ui/retroui/Card.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
@@ -9,6 +8,64 @@ interface SessionCardProps {
   viewer: AuthenticatedViewer;
   isPending: boolean;
   onSignOut: () => Promise<void>;
+}
+
+function getCopyLabel(copyState: "idle" | "copied" | "failed"): string {
+  switch (copyState) {
+    case "copied":
+      return "Copied";
+    case "failed":
+      return "Copy failed";
+    default:
+      return "Copy ID";
+  }
+}
+
+function SessionIdentity({ viewer }: { viewer: AuthenticatedViewer }) {
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="size-2 rounded-full bg-emerald-500" />
+        <Text as="p" className="text-sm text-muted-foreground">
+          Signed in · {viewer.kind}
+        </Text>
+      </div>
+      <Text as="h3">{viewer.displayName}</Text>
+      <Text as="p" className="text-sm text-muted-foreground">
+        Orders placed here are scoped to your account.
+      </Text>
+    </>
+  );
+}
+
+function UserIdRow(inputProps: {
+  canCopyUserId: boolean;
+  copyState: "idle" | "copied" | "failed";
+  userId: string;
+  onCopyUserId: () => void;
+}) {
+  const { canCopyUserId, copyState, userId, onCopyUserId } = inputProps;
+
+  return (
+    <div className="flex flex-wrap items-center gap-2 pt-1">
+      <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+        User ID
+      </Text>
+      <code className="rounded border border-border bg-muted px-2 py-1 font-mono text-xs">
+        {userId}
+      </code>
+      {canCopyUserId ? (
+        <Button
+          className="min-w-24 justify-center"
+          size="sm"
+          variant="outline"
+          onClick={onCopyUserId}
+        >
+          {getCopyLabel(copyState)}
+        </Button>
+      ) : null}
+    </div>
+  );
 }
 
 export function SessionCard(inputProps: SessionCardProps) {
@@ -28,43 +85,16 @@ export function SessionCard(inputProps: SessionCardProps) {
   };
 
   return (
-    <Card className="w-full border-border">
+    <Card className="w-full">
       <Card.Content className="flex flex-col gap-4 p-4 md:flex-row md:items-center md:justify-between">
         <div className="grid gap-1.5">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge className="rounded-none px-2.5 py-1" size="sm" variant="solid">
-              Signed in
-            </Badge>
-            <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
-              {viewer.kind}
-            </Text>
-          </div>
-          <Text as="h3">{viewer.displayName}</Text>
-          <Text as="p" className="text-sm text-muted-foreground">
-            Orders placed here are scoped to your account.
-          </Text>
-          <div className="flex flex-wrap items-center gap-2 pt-1">
-            <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
-              User ID
-            </Text>
-            <code className="rounded border border-border bg-muted px-2 py-1 font-mono text-xs">
-              {viewer.userId}
-            </code>
-            {canCopyUserId ? (
-              <Button
-                className="min-w-24 justify-center"
-                size="sm"
-                variant="outline"
-                onClick={copyUserId}
-              >
-                {copyState === "copied"
-                  ? "Copied"
-                  : copyState === "failed"
-                    ? "Copy failed"
-                    : "Copy ID"}
-              </Button>
-            ) : null}
-          </div>
+          <SessionIdentity viewer={viewer} />
+          <UserIdRow
+            canCopyUserId={canCopyUserId}
+            copyState={copyState}
+            userId={viewer.userId}
+            onCopyUserId={copyUserId}
+          />
         </div>
         <Button disabled={isPending} variant="outline" onClick={() => void onSignOut()}>
           Sign out

--- a/apps/ui/src/features/auth/hooks/useAgentApprovalPage.ts
+++ b/apps/ui/src/features/auth/hooks/useAgentApprovalPage.ts
@@ -58,24 +58,25 @@ function getApprovalError(input: {
   return routeError ?? viewerError ?? approvalsError ?? resolutionError ?? null;
 }
 
-export function useAgentApprovalPage() {
-  const { agentId, userCode } = getRouteContext();
-  const auth = usePasskeyAuth();
-  const queryClient = useQueryClient();
-  const { theme, toggleTheme } = useThemePreference();
-  const viewerQuery = useViewerQuery();
-  const viewer = viewerQuery.data;
-  const signedInViewer = viewer !== undefined && isAuthenticatedViewer(viewer) ? viewer : null;
-  const routeError = getRouteError(agentId, userCode);
-  const approvalsQuery = useQuery({
+function useApprovalsQuery(input: {
+  agentId: string | null;
+  signedInViewer: AuthenticatedViewer | null;
+}) {
+  const { agentId, signedInViewer } = input;
+
+  return useQuery({
     enabled: isReviewContextComplete(signedInViewer, agentId),
     queryFn: fetchPendingAgentApprovals,
     queryKey: pendingAgentApprovalsQueryKey,
     refetchInterval: 5_000,
     staleTime: 1_000,
   });
-  const [resolutionStatus, setResolutionStatus] = useState<ResolutionStatus>(null);
-  const resolutionMutation = useMutation({
+}
+
+function useResolutionMutation(setResolutionStatus: (status: ResolutionStatus) => void) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
     mutationFn: resolveAgentApproval,
     onSuccess: async (result) => {
       setResolutionStatus(result.status);
@@ -85,6 +86,52 @@ export function useAgentApprovalPage() {
       ]);
     },
   });
+}
+
+function createResolvePendingApproval(input: {
+  agentId: string | null;
+  resolutionMutation: ReturnType<typeof useResolutionMutation>;
+  userCode: string | null;
+}) {
+  const { agentId, resolutionMutation, userCode } = input;
+
+  return async function resolvePendingApproval(action: "approve" | "deny"): Promise<void> {
+    if (agentId === null || userCode === null) {
+      return;
+    }
+
+    await resolutionMutation.mutateAsync({ action, agentId, userCode });
+  };
+}
+
+function getSignedInViewer(viewer: ReturnType<typeof useViewerQuery>["data"]) {
+  return viewer !== undefined && isAuthenticatedViewer(viewer) ? viewer : null;
+}
+
+function useApprovalResolution(agentId: string | null, userCode: string | null) {
+  const [resolutionStatus, setResolutionStatus] = useState<ResolutionStatus>(null);
+  const resolutionMutation = useResolutionMutation(setResolutionStatus);
+  const resolvePendingApproval = createResolvePendingApproval({
+    agentId,
+    resolutionMutation,
+    userCode,
+  });
+
+  return { resolutionMutation, resolutionStatus, resolvePendingApproval };
+}
+
+export function useAgentApprovalPage() {
+  const { agentId, userCode } = getRouteContext();
+  const auth = usePasskeyAuth();
+  const { theme, toggleTheme } = useThemePreference();
+  const viewerQuery = useViewerQuery();
+  const signedInViewer = getSignedInViewer(viewerQuery.data);
+  const routeError = getRouteError(agentId, userCode);
+  const approvalsQuery = useApprovalsQuery({ agentId, signedInViewer });
+  const { resolutionMutation, resolutionStatus, resolvePendingApproval } = useApprovalResolution(
+    agentId,
+    userCode,
+  );
   const pendingApproval = getPendingApproval(agentId, approvalsQuery.data ?? []);
   const approvalError = getApprovalError({
     approvalsError: approvalsQuery.error?.message,
@@ -92,18 +139,6 @@ export function useAgentApprovalPage() {
     routeError,
     viewerError: viewerQuery.error?.message,
   });
-
-  async function resolvePendingApproval(action: "approve" | "deny"): Promise<void> {
-    if (agentId === null || userCode === null) {
-      return;
-    }
-
-    await resolutionMutation.mutateAsync({
-      action,
-      agentId,
-      userCode,
-    });
-  }
 
   return {
     approvalError,

--- a/apps/ui/src/features/coffee-shop/components/CoffeeCustomerPage.tsx
+++ b/apps/ui/src/features/coffee-shop/components/CoffeeCustomerPage.tsx
@@ -1,35 +1,19 @@
-import { Alert } from "#shared/ui/retroui/Alert.tsx";
-import { HeroBanner } from "#features/coffee-shop/components/HeroBanner.tsx";
-import { PageHeader } from "#features/coffee-shop/components/PageHeader.tsx";
+import {
+  WorkspaceAuthGate,
+  WorkspaceHeader,
+  WorkspaceWarning,
+} from "#features/coffee-shop/components/CoffeeWorkspaceShell.tsx";
+import { getCoffeeHeaderLinks } from "#features/coffee-shop/components/CoffeeWorkspaceLinks.ts";
 import { ReceiptDialog } from "#features/coffee-shop/components/ReceiptDialog.tsx";
+import { WorkspaceMetricStrip } from "#features/coffee-shop/components/WorkspaceMetricStrip.tsx";
 import { CustomerPanel } from "#features/coffee-shop/components/customer/CustomerPanel.tsx";
 import { CustomerOrdersPanel } from "#features/coffee-shop/components/customer/CustomerOrdersPanel.tsx";
 import { useCustomerWorkspace } from "#features/coffee-shop/hooks/useCustomerWorkspace.ts";
 import { usePasskeyAuth } from "#features/auth/hooks/usePasskeyAuth.ts";
-import { PasskeyGateCard } from "#features/auth/components/PasskeyGateCard.tsx";
-import { SessionCard } from "#features/auth/components/SessionCard.tsx";
-import { appRoutes } from "#app/routes.ts";
 import { isAuthenticatedViewer, type AuthenticatedViewer } from "#features/auth/lib/viewer.ts";
-import { getQueueLoad } from "#features/coffee-shop/lib/coffee.ts";
 
 function openOrdersSection(): void {
   document.getElementById("my-orders")?.scrollIntoView({ behavior: "smooth", block: "start" });
-}
-
-function getHeaderLinks() {
-  return [
-    { href: appRoutes.home, label: "Beanline Assistant", variant: "outline" as const },
-    { href: appRoutes.staff, label: "Staff queue", variant: "outline" as const },
-  ];
-}
-
-function WorkspaceWarning({ message }: { message: string }) {
-  return (
-    <Alert status="warning">
-      <Alert.Title>Workspace warning</Alert.Title>
-      <Alert.Description>{message}</Alert.Description>
-    </Alert>
-  );
 }
 
 function CustomerAuthGate(inputProps: {
@@ -38,19 +22,12 @@ function CustomerAuthGate(inputProps: {
 }) {
   const { auth, viewer } = inputProps;
 
-  return viewer !== null ? (
-    <SessionCard isPending={auth.isPending} viewer={viewer} onSignOut={auth.signOut} />
-  ) : (
-    <PasskeyGateCard
+  return (
+    <WorkspaceAuthGate
+      auth={auth}
       description="Create a customer account with one passkey, then come back with a single tap."
-      displayName={auth.displayName}
-      errorMessage={auth.errorMessage}
-      isPending={auth.isPending}
-      pendingAction={auth.pendingAction}
       title="Sign in before placing an order"
-      onCreateAccount={auth.createAccount}
-      onDisplayNameChange={auth.setDisplayName}
-      onSignIn={auth.signIn}
+      viewer={viewer}
     />
   );
 }
@@ -75,7 +52,7 @@ function CustomerWorkspacePanels(inputProps: {
   } = inputProps;
 
   return (
-    <div className="grid gap-6 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+    <div className="grid gap-5 xl:grid-cols-[minmax(0,1fr)_26rem]">
       <CustomerPanel
         draft={draftState.draft}
         menu={menu}
@@ -97,6 +74,20 @@ function CustomerWorkspacePanels(inputProps: {
   );
 }
 
+function CustomerMetricStrip(inputProps: { active: number; history: number; menu: number }) {
+  const { active, history, menu } = inputProps;
+
+  return (
+    <WorkspaceMetricStrip
+      metrics={[
+        { label: "Menu", value: String(menu) },
+        { label: "Active", value: String(active) },
+        { label: "History", value: String(history) },
+      ]}
+    />
+  );
+}
+
 function CustomerWorkspaceView(inputProps: {
   auth: ReturnType<typeof usePasskeyAuth>;
   workspace: ReturnType<typeof useCustomerWorkspace>;
@@ -105,48 +96,11 @@ function CustomerWorkspaceView(inputProps: {
   const signedInViewer = isAuthenticatedViewer(workspace.viewer) ? workspace.viewer : null;
 
   return (
-    <main className="mx-auto grid min-h-screen w-full max-w-7xl gap-5 px-4 py-4 lg:px-6">
-      <PageHeader
-        activeOrders={workspace.activeOrders.length}
-        badgeLabel="Coffee shop"
-        footerLabel="Order for yourself with passkey-scoped tickets"
-        navLinks={getHeaderLinks()}
-        theme={workspace.theme}
-        title="Customer workspace"
-        totalOrders={workspace.orders.length}
-        onToggleTheme={workspace.toggleTheme}
-      />
-      <HeroBanner
-        badgeLabel="Passkey + D1"
-        description="Your order history is scoped to your account, while the same D1-backed queue still powers the staff side."
-        isRefreshingText={
-          workspace.ordersQuery.isFetching
-            ? "Refreshing your tickets…"
-            : "Your tickets are synced with the live HTTP API."
-        }
-        metrics={[
-          { label: "Menu items", value: String(workspace.menu.length) },
-          { label: "Active orders", value: String(workspace.activeOrders.length) },
-          { label: "History", value: String(workspace.historyOrders.length) },
-        ]}
-        queueLoad={getQueueLoad(workspace.activeOrders.length)}
-        title="Place an order without seeing anyone else’s."
-      />
-      {workspace.errorMessage !== null ? (
-        <WorkspaceWarning message={workspace.errorMessage} />
-      ) : null}
+    <main className="mx-auto grid min-h-screen w-full max-w-7xl gap-5 px-4 py-5 lg:px-6">
+      <CustomerWorkspaceHeader workspace={workspace} />
+      <WorkspaceWarning message={workspace.errorMessage} />
       <CustomerAuthGate auth={auth} viewer={signedInViewer} />
-      {signedInViewer !== null ? (
-        <CustomerWorkspacePanels
-          activeOrders={workspace.activeOrders}
-          createOrderMutation={workspace.createOrderMutation}
-          draftState={workspace.draftState}
-          historyOrders={workspace.historyOrders}
-          menu={workspace.menu}
-          ordersQuery={workspace.ordersQuery}
-          submitOrder={workspace.submitOrder}
-        />
-      ) : null}
+      <CustomerSignedInWorkspace signedInViewer={signedInViewer} workspace={workspace} />
       <ReceiptDialog
         actionLabel="Open my orders"
         order={workspace.receiptOrder}
@@ -154,6 +108,49 @@ function CustomerWorkspaceView(inputProps: {
         onOpenOrders={openOrdersSection}
       />
     </main>
+  );
+}
+
+function CustomerWorkspaceHeader(inputProps: {
+  workspace: ReturnType<typeof useCustomerWorkspace>;
+}) {
+  const { workspace } = inputProps;
+
+  return (
+    <WorkspaceHeader
+      activeOrders={workspace.activeOrders.length}
+      footerLabel="Order for yourself with passkey-scoped tickets"
+      navLinks={getCoffeeHeaderLinks("staff")}
+      theme={workspace.theme}
+      title="Customer workspace"
+      totalOrders={workspace.orders.length}
+      onToggleTheme={workspace.toggleTheme}
+    >
+      <CustomerMetricStrip
+        active={workspace.activeOrders.length}
+        history={workspace.historyOrders.length}
+        menu={workspace.menu.length}
+      />
+    </WorkspaceHeader>
+  );
+}
+
+function CustomerSignedInWorkspace(inputProps: {
+  signedInViewer: AuthenticatedViewer | null;
+  workspace: ReturnType<typeof useCustomerWorkspace>;
+}) {
+  const { signedInViewer, workspace } = inputProps;
+
+  return signedInViewer === null ? null : (
+    <CustomerWorkspacePanels
+      activeOrders={workspace.activeOrders}
+      createOrderMutation={workspace.createOrderMutation}
+      draftState={workspace.draftState}
+      historyOrders={workspace.historyOrders}
+      menu={workspace.menu}
+      ordersQuery={workspace.ordersQuery}
+      submitOrder={workspace.submitOrder}
+    />
   );
 }
 

--- a/apps/ui/src/features/coffee-shop/components/CoffeeStaffPage.tsx
+++ b/apps/ui/src/features/coffee-shop/components/CoffeeStaffPage.tsx
@@ -1,33 +1,19 @@
-import { Alert } from "#shared/ui/retroui/Alert.tsx";
-import { HeroBanner } from "#features/coffee-shop/components/HeroBanner.tsx";
-import { PageHeader } from "#features/coffee-shop/components/PageHeader.tsx";
+import {
+  WorkspaceAuthGate,
+  WorkspaceHeader,
+  WorkspaceWarning,
+} from "#features/coffee-shop/components/CoffeeWorkspaceShell.tsx";
+import { getCoffeeHeaderLinks } from "#features/coffee-shop/components/CoffeeWorkspaceLinks.ts";
+import { WorkspaceMetricStrip } from "#features/coffee-shop/components/WorkspaceMetricStrip.tsx";
 import { BaristaPanel } from "#features/coffee-shop/components/barista/BaristaPanel.tsx";
 import { useStaffWorkspace } from "#features/coffee-shop/hooks/useStaffWorkspace.ts";
 import { usePasskeyAuth } from "#features/auth/hooks/usePasskeyAuth.ts";
-import { PasskeyGateCard } from "#features/auth/components/PasskeyGateCard.tsx";
-import { SessionCard } from "#features/auth/components/SessionCard.tsx";
-import { appRoutes } from "#app/routes.ts";
 import {
   isAuthenticatedViewer,
   isStaffViewer,
   type AuthenticatedViewer,
 } from "#features/auth/lib/viewer.ts";
-
-function getHeaderLinks() {
-  return [
-    { href: appRoutes.home, label: "Beanline Assistant", variant: "outline" as const },
-    { href: appRoutes.shop, label: "Customer workspace", variant: "outline" as const },
-  ];
-}
-
-function WorkspaceWarning({ message }: { message: string }) {
-  return (
-    <Alert status="warning">
-      <Alert.Title>Workspace warning</Alert.Title>
-      <Alert.Description>{message}</Alert.Description>
-    </Alert>
-  );
-}
+import { Alert } from "#shared/ui/retroui/Alert.tsx";
 
 function StaffAccessWarning() {
   return (
@@ -46,19 +32,12 @@ function StaffAuthGate(inputProps: {
 }) {
   const { auth, viewer } = inputProps;
 
-  return viewer !== null ? (
-    <SessionCard isPending={auth.isPending} viewer={viewer} onSignOut={auth.signOut} />
-  ) : (
-    <PasskeyGateCard
+  return (
+    <WorkspaceAuthGate
+      auth={auth}
       description="Only staff-listed accounts can manage the live queue."
-      displayName={auth.displayName}
-      errorMessage={auth.errorMessage}
-      isPending={auth.isPending}
-      pendingAction={auth.pendingAction}
       title="Sign in with your staff passkey"
-      onCreateAccount={auth.createAccount}
-      onDisplayNameChange={auth.setDisplayName}
-      onSignIn={auth.signIn}
+      viewer={viewer}
     />
   );
 }
@@ -68,8 +47,6 @@ function StaffQueuePanel(inputProps: {
   handleOrderAction: ReturnType<typeof useStaffWorkspace>["handleOrderAction"];
   historyOrders: ReturnType<typeof useStaffWorkspace>["historyOrders"];
   pendingOrderId: ReturnType<typeof useStaffWorkspace>["pendingOrderId"];
-  queueLoad: ReturnType<typeof useStaffWorkspace>["queueLoad"];
-  readyCount: ReturnType<typeof useStaffWorkspace>["readyCount"];
   selectedOrder: ReturnType<typeof useStaffWorkspace>["selectedOrder"];
   setSelectedOrderId: ReturnType<typeof useStaffWorkspace>["setSelectedOrderId"];
 }) {
@@ -78,8 +55,6 @@ function StaffQueuePanel(inputProps: {
     handleOrderAction,
     historyOrders,
     pendingOrderId,
-    queueLoad,
-    readyCount,
     selectedOrder,
     setSelectedOrderId,
   } = inputProps;
@@ -89,12 +64,30 @@ function StaffQueuePanel(inputProps: {
       activeOrders={activeOrders}
       historyOrders={historyOrders.slice(0, 6)}
       pendingOrderId={pendingOrderId}
-      queueLoad={queueLoad}
-      readyCount={readyCount}
       selectedOrder={selectedOrder}
       onAction={handleOrderAction}
       onInspect={setSelectedOrderId}
       onOpenChange={(open) => !open && setSelectedOrderId(null)}
+    />
+  );
+}
+
+function StaffMetricStrip(inputProps: {
+  active: number;
+  history: number;
+  load: number;
+  ready: number;
+}) {
+  const { active, history, load, ready } = inputProps;
+
+  return (
+    <WorkspaceMetricStrip
+      metrics={[
+        { label: "Active", value: String(active) },
+        { label: "Ready", value: String(ready) },
+        { label: "History", value: String(history) },
+        { label: "Load", progress: load, value: `${load}%` },
+      ]}
     />
   );
 }
@@ -108,52 +101,64 @@ function StaffWorkspaceView(inputProps: {
   const isStaffSession = signedInViewer !== null && isStaffViewer(signedInViewer);
 
   return (
-    <main className="mx-auto grid min-h-screen w-full max-w-7xl gap-5 px-4 py-4 lg:px-6">
-      <PageHeader
-        activeOrders={workspace.activeOrders.length}
-        badgeLabel="Coffee shop"
-        footerLabel="Staff-only queue management"
-        navLinks={getHeaderLinks()}
-        theme={workspace.theme}
-        title="Staff workspace"
-        totalOrders={workspace.orders.length}
-        onToggleTheme={workspace.toggleTheme}
-      />
-      <HeroBanner
-        badgeLabel="Queue operations"
-        description="This side of the workspace can move tickets through brewing, ready, pickup, and cancellation without exposing customer ordering controls."
-        isRefreshingText={
-          workspace.ordersQuery.isFetching
-            ? "Refreshing the queue…"
-            : "Queue synced with the live HTTP API."
-        }
-        metrics={[
-          { label: "Active orders", value: String(workspace.activeOrders.length) },
-          { label: "Ready now", value: String(workspace.readyCount) },
-          { label: "Recent history", value: String(workspace.historyOrders.length) },
-        ]}
-        queueLoad={workspace.queueLoad}
-        title="Run the line without seeing the customer composer."
-      />
-      {workspace.errorMessage !== null ? (
-        <WorkspaceWarning message={workspace.errorMessage} />
-      ) : null}
+    <main className="mx-auto grid min-h-screen w-full max-w-7xl gap-5 px-4 py-5 lg:px-6">
+      <StaffWorkspaceHeader workspace={workspace} />
+      <WorkspaceWarning message={workspace.errorMessage} />
       <StaffAuthGate auth={auth} viewer={signedInViewer} />
-      {signedInViewer !== null && !isStaffSession ? <StaffAccessWarning /> : null}
-      {isStaffSession ? (
-        <StaffQueuePanel
-          activeOrders={workspace.activeOrders}
-          handleOrderAction={workspace.handleOrderAction}
-          historyOrders={workspace.historyOrders}
-          pendingOrderId={workspace.pendingOrderId}
-          queueLoad={workspace.queueLoad}
-          readyCount={workspace.readyCount}
-          selectedOrder={workspace.selectedOrder}
-          setSelectedOrderId={workspace.setSelectedOrderId}
-        />
-      ) : null}
+      <StaffWorkspaceAccess isStaffSession={isStaffSession} signedInViewer={signedInViewer} />
+      <StaffSignedInWorkspace isStaffSession={isStaffSession} workspace={workspace} />
     </main>
   );
+}
+
+function StaffWorkspaceHeader(inputProps: { workspace: ReturnType<typeof useStaffWorkspace> }) {
+  const { workspace } = inputProps;
+
+  return (
+    <WorkspaceHeader
+      activeOrders={workspace.activeOrders.length}
+      footerLabel="Staff-only queue management"
+      navLinks={getCoffeeHeaderLinks("shop")}
+      theme={workspace.theme}
+      title="Staff workspace"
+      totalOrders={workspace.orders.length}
+      onToggleTheme={workspace.toggleTheme}
+    >
+      <StaffMetricStrip
+        active={workspace.activeOrders.length}
+        history={workspace.historyOrders.length}
+        load={workspace.queueLoad}
+        ready={workspace.readyCount}
+      />
+    </WorkspaceHeader>
+  );
+}
+
+function StaffWorkspaceAccess(inputProps: {
+  isStaffSession: boolean;
+  signedInViewer: AuthenticatedViewer | null;
+}) {
+  const { isStaffSession, signedInViewer } = inputProps;
+
+  return signedInViewer !== null && !isStaffSession ? <StaffAccessWarning /> : null;
+}
+
+function StaffSignedInWorkspace(inputProps: {
+  isStaffSession: boolean;
+  workspace: ReturnType<typeof useStaffWorkspace>;
+}) {
+  const { isStaffSession, workspace } = inputProps;
+
+  return isStaffSession ? (
+    <StaffQueuePanel
+      activeOrders={workspace.activeOrders}
+      handleOrderAction={workspace.handleOrderAction}
+      historyOrders={workspace.historyOrders}
+      pendingOrderId={workspace.pendingOrderId}
+      selectedOrder={workspace.selectedOrder}
+      setSelectedOrderId={workspace.setSelectedOrderId}
+    />
+  ) : null;
 }
 
 export function CoffeeStaffPage() {

--- a/apps/ui/src/features/coffee-shop/components/CoffeeWorkspaceLinks.ts
+++ b/apps/ui/src/features/coffee-shop/components/CoffeeWorkspaceLinks.ts
@@ -1,0 +1,11 @@
+import { appRoutes } from "#app/routes.ts";
+import type { NavigationLinkProps } from "#features/coffee-shop/components/PageHeader.tsx";
+
+export function getCoffeeHeaderLinks(target: "shop" | "staff"): readonly NavigationLinkProps[] {
+  const workspaceLink =
+    target === "staff"
+      ? { href: appRoutes.staff, label: "Staff queue", variant: "outline" as const }
+      : { href: appRoutes.shop, label: "Customer workspace", variant: "outline" as const };
+
+  return [{ href: appRoutes.home, label: "Beanline Assistant", variant: "outline" }, workspaceLink];
+}

--- a/apps/ui/src/features/coffee-shop/components/CoffeeWorkspaceShell.tsx
+++ b/apps/ui/src/features/coffee-shop/components/CoffeeWorkspaceShell.tsx
@@ -1,0 +1,81 @@
+import { PasskeyGateCard } from "#features/auth/components/PasskeyGateCard.tsx";
+import { SessionCard } from "#features/auth/components/SessionCard.tsx";
+import type { AuthenticatedViewer } from "#features/auth/lib/viewer.ts";
+import { PageHeader } from "#features/coffee-shop/components/PageHeader.tsx";
+import { Alert } from "#shared/ui/retroui/Alert.tsx";
+import type { ThemePreference } from "#shared/hooks/useThemePreference.ts";
+import type { NavigationLinkProps } from "#features/coffee-shop/components/PageHeader.tsx";
+import type { usePasskeyAuth } from "#features/auth/hooks/usePasskeyAuth.ts";
+import type { ReactNode } from "react";
+
+export function WorkspaceWarning({ message }: { message: string | null }) {
+  return message === null ? null : (
+    <Alert status="warning">
+      <Alert.Title>Workspace warning</Alert.Title>
+      <Alert.Description>{message}</Alert.Description>
+    </Alert>
+  );
+}
+
+export function WorkspaceAuthGate(inputProps: {
+  auth: ReturnType<typeof usePasskeyAuth>;
+  description: string;
+  title: string;
+  viewer: AuthenticatedViewer | null;
+}) {
+  const { auth, description, title, viewer } = inputProps;
+
+  return viewer !== null ? (
+    <SessionCard isPending={auth.isPending} viewer={viewer} onSignOut={auth.signOut} />
+  ) : (
+    <PasskeyGateCard
+      description={description}
+      displayName={auth.displayName}
+      errorMessage={auth.errorMessage}
+      isPending={auth.isPending}
+      pendingAction={auth.pendingAction}
+      title={title}
+      onCreateAccount={auth.createAccount}
+      onDisplayNameChange={auth.setDisplayName}
+      onSignIn={auth.signIn}
+    />
+  );
+}
+
+export function WorkspaceHeader(inputProps: {
+  activeOrders: number;
+  children: ReactNode;
+  footerLabel: string;
+  navLinks: readonly NavigationLinkProps[];
+  theme: ThemePreference;
+  title: string;
+  totalOrders: number;
+  onToggleTheme: () => void;
+}) {
+  const {
+    activeOrders,
+    children,
+    footerLabel,
+    navLinks,
+    theme,
+    title,
+    totalOrders,
+    onToggleTheme,
+  } = inputProps;
+
+  return (
+    <>
+      <PageHeader
+        activeOrders={activeOrders}
+        badgeLabel="Coffee shop"
+        footerLabel={footerLabel}
+        navLinks={navLinks}
+        theme={theme}
+        title={title}
+        totalOrders={totalOrders}
+        onToggleTheme={onToggleTheme}
+      />
+      {children}
+    </>
+  );
+}

--- a/apps/ui/src/features/coffee-shop/components/PageHeader.tsx
+++ b/apps/ui/src/features/coffee-shop/components/PageHeader.tsx
@@ -1,6 +1,5 @@
 import { useState, type ReactNode } from "react";
 import { Menu } from "lucide-react";
-import { Badge } from "#shared/ui/retroui/Badge.tsx";
 import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Drawer } from "#shared/ui/retroui/Drawer.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
@@ -26,7 +25,7 @@ interface NavigationProps {
   onToggleTheme: () => void;
 }
 
-interface NavigationLinkProps {
+export interface NavigationLinkProps {
   href: string;
   label: string;
   variant: "default" | "ghost" | "outline";
@@ -36,13 +35,11 @@ function HeaderIntro(inputProps: Pick<PageHeaderProps, "badgeLabel" | "title">) 
   const { badgeLabel, title } = inputProps;
 
   return (
-    <div className="min-w-0 flex-1 grid gap-1.5">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge className="rounded-none bg-primary px-2.5 py-1" size="sm" variant="surface">
-          {badgeLabel}
-        </Badge>
-      </div>
-      <Text as="h1" className="max-w-3xl text-xl leading-none md:text-2xl">
+    <div className="grid min-w-0 flex-1 gap-1">
+      <Text as="p" className="text-xs font-medium text-muted-foreground">
+        {badgeLabel}
+      </Text>
+      <Text as="h1" className="max-w-3xl text-2xl font-semibold leading-tight md:text-3xl">
         {title}
       </Text>
     </div>
@@ -79,12 +76,12 @@ function SessionSummary({
   totalOrders,
 }: Pick<NavigationProps, "activeOrders" | "totalOrders">) {
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Badge className="rounded-none px-2.5 py-1" size="sm" variant="solid">
-        {activeOrders} active
-      </Badge>
-      <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
-        {totalOrders} total this session
+    <div className="flex flex-wrap items-center gap-3 text-sm text-muted-foreground">
+      <Text as="p">
+        <span className="font-semibold text-foreground">{activeOrders}</span> active
+      </Text>
+      <Text as="p">
+        <span className="font-semibold text-foreground">{totalOrders}</span> total
       </Text>
     </div>
   );
@@ -107,12 +104,10 @@ function MobileNavigation(inputProps: NavigationProps) {
         </Button>
       </Drawer.Trigger>
       {isMenuOpen ? (
-        <Drawer.Content className="border-l-2 border-border bg-card">
-          <Drawer.Header className="border-b-2 border-border bg-card px-4 py-4 text-left">
+        <Drawer.Content className="border-l border-border bg-card">
+          <Drawer.Header className="border-b border-border bg-card px-4 py-4 text-left">
             <Drawer.Title>Workspace menu</Drawer.Title>
-            <Drawer.Description>
-              Navigation and theme controls for this workspace.
-            </Drawer.Description>
+            <Drawer.Description>Navigation and theme controls.</Drawer.Description>
           </Drawer.Header>
           <div className="grid gap-4 p-4">
             <SessionSummary activeOrders={activeOrders} totalOrders={totalOrders} />
@@ -144,8 +139,8 @@ export function PageHeader(inputProps: PageHeaderProps) {
   } = inputProps;
 
   return (
-    <header className="border-2 border-border bg-card shadow-md">
-      <div className="flex items-start justify-between gap-3 px-4 py-3 md:px-5 md:py-4">
+    <header className="grid gap-4 border-b border-border pb-4">
+      <div className="flex min-h-14 items-start justify-between gap-3">
         <HeaderIntro badgeLabel={badgeLabel} title={title} />
         <DesktopNavigation navLinks={navLinks} theme={theme} onToggleTheme={onToggleTheme} />
         <MobileNavigation
@@ -156,8 +151,8 @@ export function PageHeader(inputProps: PageHeaderProps) {
           onToggleTheme={onToggleTheme}
         />
       </div>
-      <div className="flex flex-wrap items-center justify-between gap-2 border-t-2 border-border bg-background px-4 py-2.5 md:px-5">
-        <Text as="p" className="text-xs uppercase tracking-[0.12em] text-muted-foreground">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Text as="p" className="text-sm text-muted-foreground">
           {footerLabel}
         </Text>
         <SessionSummary activeOrders={activeOrders} totalOrders={totalOrders} />

--- a/apps/ui/src/features/coffee-shop/components/ReceiptDialog.tsx
+++ b/apps/ui/src/features/coffee-shop/components/ReceiptDialog.tsx
@@ -18,47 +18,81 @@ export function ReceiptDialog(inputProps: ReceiptDialogProps) {
   return (
     <Dialog open={order !== null} onOpenChange={(open) => !open && onClose()}>
       {order !== null ? (
-        <Dialog.Content className="max-w-xl" size="lg">
-          <Dialog.Header>Order sent to the queue</Dialog.Header>
-          <Dialog.Description className="px-4 pt-3 text-sm text-muted-foreground">
-            Review the new ticket details, then keep ordering or jump to your active orders.
-          </Dialog.Description>
-          <div className="grid gap-5 px-4 pb-5 pt-1">
-            <div className="flex flex-wrap items-center gap-3">
-              <StatusBadge status={order.status} />
-              <Text as="p" className="text-sm text-muted-foreground">
-                Ticket {order.id} opened at {formatOrderTime(order.createdAt)}
-              </Text>
-            </div>
-            <Text as="h3">{order.customerName}</Text>
-            <Text as="p" className="text-lg">
-              {order.drinkName}, {order.size}, {order.temperature}, {order.milk} milk, {order.shots}{" "}
-              shot(s)
-            </Text>
-            {order.notes !== undefined ? (
-              <Text as="p" className="text-base text-muted-foreground">
-                Notes: {order.notes}
-              </Text>
-            ) : null}
-            <Text as="h4" className="text-2xl">
-              {formatPrice(order.priceCents)}
-            </Text>
-          </div>
-          <Dialog.Footer position="static">
-            <Button variant="outline" onClick={onClose}>
-              Keep ordering
-            </Button>
-            <Button
-              onClick={() => {
-                onOpenOrders();
-                onClose();
-              }}
-            >
-              {actionLabel}
-            </Button>
-          </Dialog.Footer>
-        </Dialog.Content>
+        <ReceiptContent
+          actionLabel={actionLabel}
+          order={order}
+          onClose={onClose}
+          onOpenOrders={onOpenOrders}
+        />
       ) : null}
     </Dialog>
+  );
+}
+
+function ReceiptContent(inputProps: {
+  actionLabel: string;
+  order: CoffeeOrder;
+  onClose: () => void;
+  onOpenOrders: () => void;
+}) {
+  const { actionLabel, order, onClose, onOpenOrders } = inputProps;
+
+  return (
+    <Dialog.Content className="max-w-xl" size="lg">
+      <Dialog.Header>Order sent to the queue</Dialog.Header>
+      <Dialog.Description className="px-4 pt-3 text-sm text-muted-foreground">
+        Review the new ticket, then keep ordering or jump to active tickets.
+      </Dialog.Description>
+      <ReceiptDetails order={order} />
+      <ReceiptFooter actionLabel={actionLabel} onClose={onClose} onOpenOrders={onOpenOrders} />
+    </Dialog.Content>
+  );
+}
+
+function ReceiptDetails({ order }: { order: CoffeeOrder }) {
+  return (
+    <div className="grid gap-5 px-4 pb-5 pt-1">
+      <div className="flex flex-wrap items-center gap-3">
+        <StatusBadge status={order.status} />
+        <Text as="p" className="text-sm text-muted-foreground">
+          Ticket {order.id} opened at {formatOrderTime(order.createdAt)}
+        </Text>
+      </div>
+      <Text as="h3">{order.customerName}</Text>
+      <Text as="p" className="text-lg">
+        {order.drinkName}, {order.size}, {order.temperature}, {order.milk} milk, {order.shots}{" "}
+        shot(s)
+      </Text>
+      {order.notes !== undefined ? (
+        <Text as="p" className="text-base text-muted-foreground">
+          Notes: {order.notes}
+        </Text>
+      ) : null}
+      <Text as="h4" className="text-2xl">
+        {formatPrice(order.priceCents)}
+      </Text>
+    </div>
+  );
+}
+
+function ReceiptFooter(inputProps: {
+  actionLabel: string;
+  onClose: () => void;
+  onOpenOrders: () => void;
+}) {
+  const { actionLabel, onClose, onOpenOrders } = inputProps;
+
+  function openOrders(): void {
+    onOpenOrders();
+    onClose();
+  }
+
+  return (
+    <Dialog.Footer position="static">
+      <Button variant="outline" onClick={onClose}>
+        Keep ordering
+      </Button>
+      <Button onClick={openOrders}>{actionLabel}</Button>
+    </Dialog.Footer>
   );
 }

--- a/apps/ui/src/features/coffee-shop/components/WorkspaceMetricStrip.tsx
+++ b/apps/ui/src/features/coffee-shop/components/WorkspaceMetricStrip.tsx
@@ -1,0 +1,35 @@
+import { Card } from "#shared/ui/retroui/Card.tsx";
+import { Progress } from "#shared/ui/retroui/Progress.tsx";
+import { Text } from "#shared/ui/retroui/Text.tsx";
+
+export interface WorkspaceMetric {
+  label: string;
+  progress?: number;
+  value: string;
+}
+
+export function WorkspaceMetricStrip({ metrics }: { metrics: readonly WorkspaceMetric[] }) {
+  return (
+    <Card>
+      <Card.Content className="flex flex-wrap gap-5 p-4">
+        {metrics.map((metric) => (
+          <Metric key={metric.label} {...metric} />
+        ))}
+      </Card.Content>
+    </Card>
+  );
+}
+
+function Metric({ label, progress, value }: WorkspaceMetric) {
+  return (
+    <div className="grid min-w-20 gap-1">
+      <Text as="p" className="text-xs text-muted-foreground">
+        {label}
+      </Text>
+      <Text as="p" className="text-2xl font-semibold">
+        {value}
+      </Text>
+      {progress !== undefined ? <Progress className="h-1.5" value={progress} /> : null}
+    </div>
+  );
+}

--- a/apps/ui/src/features/coffee-shop/components/barista/BaristaPanel.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/BaristaPanel.tsx
@@ -1,6 +1,5 @@
 import { OrderDetailsDrawer } from "#features/coffee-shop/components/barista/OrderDetailsDrawer.tsx";
 import { QueueBoardCard } from "#features/coffee-shop/components/barista/QueueBoardCard.tsx";
-import { QueueSummary } from "#features/coffee-shop/components/barista/QueueSummary.tsx";
 import { RecentActivityCard } from "#features/coffee-shop/components/barista/RecentActivityCard.tsx";
 import type { CoffeeOrder, OrderAction } from "#features/coffee-shop/lib/coffee.ts";
 
@@ -8,8 +7,6 @@ interface BaristaPanelProps {
   activeOrders: readonly CoffeeOrder[];
   historyOrders: readonly CoffeeOrder[];
   pendingOrderId: string | null;
-  queueLoad: number;
-  readyCount: number;
   selectedOrder: CoffeeOrder | null;
   onAction: (orderId: string, action: OrderAction) => void;
   onInspect: (orderId: string) => void;
@@ -21,8 +18,6 @@ export function BaristaPanel(inputProps: BaristaPanelProps) {
     activeOrders,
     historyOrders,
     pendingOrderId,
-    queueLoad,
-    readyCount,
     selectedOrder,
     onAction,
     onInspect,
@@ -30,13 +25,7 @@ export function BaristaPanel(inputProps: BaristaPanelProps) {
   } = inputProps;
 
   return (
-    <section className="grid gap-6">
-      <QueueSummary
-        activeCount={activeOrders.length}
-        historyCount={historyOrders.length}
-        queueLoad={queueLoad}
-        readyCount={readyCount}
-      />
+    <section className="grid gap-5">
       <QueueBoardCard
         orders={activeOrders}
         pendingOrderId={pendingOrderId}

--- a/apps/ui/src/features/coffee-shop/components/barista/OrderDetailsDrawer.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/OrderDetailsDrawer.tsx
@@ -18,7 +18,7 @@ export function OrderDetailsDrawer(inputProps: OrderDetailsDrawerProps) {
   return (
     <Drawer open={order !== null} direction="right" onOpenChange={onOpenChange}>
       {order !== null ? (
-        <Drawer.Content className="border-l-2 border-border">
+        <Drawer.Content className="border-l border-border">
           <Drawer.Header>
             <Drawer.Title>{order.drinkName}</Drawer.Title>
             <Drawer.Description>Ticket {order.id}</Drawer.Description>
@@ -40,7 +40,7 @@ export function OrderDetailsDrawer(inputProps: OrderDetailsDrawerProps) {
               <Button
                 key={option.action}
                 disabled={pending}
-                variant={option.action === "cancel" ? "outline" : "default"}
+                variant={option.action === "cancel" ? "ghost" : "default"}
                 onClick={() => onAction(order.id, option.action)}
               >
                 {option.label}
@@ -63,8 +63,8 @@ interface DetailLineProps {
 
 function DetailLine({ label, value }: DetailLineProps) {
   return (
-    <div className="grid gap-1 border-b-2 border-dashed border-border pb-3">
-      <Text as="p" className="text-sm uppercase tracking-[0.08em] text-muted-foreground">
+    <div className="grid gap-1 border-b border-border pb-3">
+      <Text as="p" className="text-sm text-muted-foreground">
         {label}
       </Text>
       <Text as="p">{value}</Text>

--- a/apps/ui/src/features/coffee-shop/components/barista/QueueBoardCard.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/QueueBoardCard.tsx
@@ -15,11 +15,11 @@ export function QueueBoardCard(inputProps: QueueBoardCardProps) {
   const { orders, pendingOrderId, onAction, onInspect } = inputProps;
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
         <Text as="h3">Barista queue</Text>
         <Text as="p" className="text-sm text-muted-foreground">
-          Live ticket actions are mapped directly to the existing order transition endpoints.
+          Move active tickets through the line.
         </Text>
       </Card.Header>
       <Card.Content>

--- a/apps/ui/src/features/coffee-shop/components/barista/QueueRowActions.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/QueueRowActions.tsx
@@ -15,7 +15,7 @@ export function QueueRowActions({ order, pending, onAction }: QueueRowActionsPro
         <Button
           key={option.action}
           size="sm"
-          variant={option.action === "cancel" ? "outline" : "default"}
+          variant={option.action === "cancel" ? "ghost" : "outline"}
           onClick={() => onAction(order.id, option.action)}
           disabled={pending}
         >

--- a/apps/ui/src/features/coffee-shop/components/barista/QueueTable.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/QueueTable.tsx
@@ -2,7 +2,7 @@ import { Button } from "#shared/ui/retroui/Button.tsx";
 import { Table } from "#shared/ui/retroui/Table.tsx";
 import { StatusBadge } from "#shared/ui/StatusBadge.tsx";
 import { QueueRowActions } from "#features/coffee-shop/components/barista/QueueRowActions.tsx";
-import { formatOrderTime, formatPrice } from "#features/coffee-shop/lib/coffee.ts";
+import { formatOrderTime } from "#features/coffee-shop/lib/coffee.ts";
 import type { CoffeeOrder, OrderAction } from "#features/coffee-shop/lib/coffee.ts";
 
 interface QueueTableProps {
@@ -21,22 +21,22 @@ export function QueueTable(inputProps: QueueTableProps) {
         <Table.Row>
           <Table.Head>Ticket</Table.Head>
           <Table.Head>Drink</Table.Head>
+          <Table.Head>Customer</Table.Head>
           <Table.Head>Status</Table.Head>
           <Table.Head>Opened</Table.Head>
-          <Table.Head>Total</Table.Head>
           <Table.Head>Actions</Table.Head>
         </Table.Row>
       </Table.Header>
       <Table.Body>
         {orders.map((order) => (
           <Table.Row key={order.id}>
-            <Table.Cell className="font-head">{order.id}</Table.Cell>
+            <Table.Cell className="font-medium">{order.id}</Table.Cell>
             <Table.Cell>{order.drinkName}</Table.Cell>
+            <Table.Cell>{order.customerName}</Table.Cell>
             <Table.Cell>
               <StatusBadge status={order.status} />
             </Table.Cell>
             <Table.Cell>{formatOrderTime(order.createdAt)}</Table.Cell>
-            <Table.Cell>{formatPrice(order.priceCents)}</Table.Cell>
             <Table.Cell className="space-y-2">
               <QueueRowActions
                 order={order}

--- a/apps/ui/src/features/coffee-shop/components/barista/RecentActivityCard.tsx
+++ b/apps/ui/src/features/coffee-shop/components/barista/RecentActivityCard.tsx
@@ -15,15 +15,15 @@ export function RecentActivityCard({ orders, onInspect }: RecentActivityCardProp
   }
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
         <Text as="h3">Recent activity</Text>
       </Card.Header>
       <Card.Content className="grid gap-3">
         {orders.map((order) => (
           <button
             key={order.id}
-            className="grid gap-2 border-2 border-border bg-background p-3 text-left shadow-xs transition hover:-translate-x-0.5 hover:-translate-y-0.5 hover:shadow-sm"
+            className="grid gap-2 rounded-md border border-border bg-background p-3 text-left transition hover:bg-muted/50"
             type="button"
             onClick={() => onInspect(order.id)}
           >

--- a/apps/ui/src/features/coffee-shop/components/customer/CustomerOrdersPanel.tsx
+++ b/apps/ui/src/features/coffee-shop/components/customer/CustomerOrdersPanel.tsx
@@ -11,64 +11,72 @@ interface CustomerOrdersPanelProps {
   isRefreshing: boolean;
 }
 
-function OrdersList(inputProps: {
-  orders: readonly CoffeeOrder[];
-  title: string;
-  emptyMessage: string;
-}) {
-  const { emptyMessage, orders, title } = inputProps;
+export function CustomerOrdersPanel(inputProps: CustomerOrdersPanelProps) {
+  const { activeOrders, historyOrders, isRefreshing } = inputProps;
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
-        <Text as="h3">{title}</Text>
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
+        <Text as="h3">My tickets</Text>
+        <Text as="p" className="text-sm text-muted-foreground">
+          {isRefreshing ? "Refreshing tickets..." : "Only your account-scoped tickets appear here."}
+        </Text>
       </Card.Header>
-      <Card.Content className="grid gap-3">
-        {orders.length === 0 ? (
-          <Alert className="border-border bg-card" status="info">
-            <Alert.Title>{emptyMessage}</Alert.Title>
-          </Alert>
-        ) : (
-          orders.map((order) => (
-            <div key={order.id} className="grid gap-2 border-2 border-border bg-background p-3">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <Text as="h4">{order.drinkName}</Text>
-                <StatusBadge status={order.status} />
-              </div>
-              <Text as="p" className="text-sm text-muted-foreground">
-                {order.id} · {formatPrice(order.priceCents)} · {formatOrderTime(order.createdAt)}
-              </Text>
-            </div>
-          ))
-        )}
+      <Card.Content className="grid gap-5">
+        <OrderGroup emptyMessage="No active tickets yet." orders={activeOrders} title="Active" />
+        <OrderGroup
+          emptyMessage="Closed tickets land here."
+          orders={historyOrders}
+          title="History"
+        />
       </Card.Content>
     </Card>
   );
 }
 
-export function CustomerOrdersPanel(inputProps: CustomerOrdersPanelProps) {
-  const { activeOrders, historyOrders, isRefreshing } = inputProps;
+function OrderGroup(inputProps: OrderGroupProps) {
+  const { emptyMessage, orders, title } = inputProps;
 
   return (
-    <section className="grid gap-6">
-      <Card className="w-full border-border bg-primary text-primary-foreground">
-        <Card.Content className="grid gap-2 p-4">
-          <Text as="h3">My orders</Text>
-          <Text as="p" className="text-sm text-primary-foreground/80">
-            {isRefreshing ? "Refreshing your order list…" : "Only your tickets are visible here."}
-          </Text>
-        </Card.Content>
-      </Card>
-      <OrdersList
-        emptyMessage="You do not have any active orders yet."
-        orders={activeOrders}
-        title="Active orders"
-      />
-      <OrdersList
-        emptyMessage="Completed and cancelled orders will land here."
-        orders={historyOrders}
-        title="History"
-      />
+    <section className="grid gap-3">
+      <Text as="p" className="text-xs font-medium text-muted-foreground">
+        {title}
+      </Text>
+      {orders.length === 0 ? <EmptyOrders message={emptyMessage} /> : <OrderRows orders={orders} />}
     </section>
+  );
+}
+
+interface OrderGroupProps {
+  emptyMessage: string;
+  orders: readonly CoffeeOrder[];
+  title: string;
+}
+
+function EmptyOrders({ message }: { message: string }) {
+  return (
+    <Alert className="border-border bg-background" status="info">
+      <Alert.Title>{message}</Alert.Title>
+    </Alert>
+  );
+}
+
+function OrderRows({ orders }: { orders: readonly CoffeeOrder[] }) {
+  return orders.map((order) => <OrderRow key={order.id} order={order} />);
+}
+
+function OrderRow({ order }: { order: CoffeeOrder }) {
+  return (
+    <div className="grid gap-2 rounded-md border border-border bg-background p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <Text as="h4" className="font-semibold">
+          {order.drinkName}
+        </Text>
+        <StatusBadge status={order.status} />
+      </div>
+      <Text as="p" className="text-sm text-muted-foreground">
+        {order.id} · {formatPrice(order.priceCents)} · {formatOrderTime(order.createdAt)}
+      </Text>
+    </div>
   );
 }

--- a/apps/ui/src/features/coffee-shop/components/customer/CustomerPanel.tsx
+++ b/apps/ui/src/features/coffee-shop/components/customer/CustomerPanel.tsx
@@ -1,6 +1,5 @@
 import { Alert } from "#shared/ui/retroui/Alert.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
-import { MenuCatalogCard } from "#features/coffee-shop/components/customer/MenuCatalogCard.tsx";
 import { OrderComposerCard } from "#features/coffee-shop/components/customer/OrderComposerCard.tsx";
 import type { MenuItem, OrderDraft } from "#features/coffee-shop/lib/coffee.ts";
 
@@ -31,7 +30,7 @@ export function CustomerPanel(inputProps: CustomerPanelProps) {
   }
 
   return (
-    <section className="grid gap-6">
+    <section className="grid gap-5">
       <OrderComposerCard
         draft={draft}
         item={selectedItem}
@@ -42,7 +41,6 @@ export function CustomerPanel(inputProps: CustomerPanelProps) {
         onSubmit={onSubmit}
         onUpdateDraft={onUpdateDraft}
       />
-      <MenuCatalogCard menu={menu} selectedDrinkId={draft.drinkId} onSelectDrink={onSelectDrink} />
     </section>
   );
 }

--- a/apps/ui/src/features/coffee-shop/components/customer/OrderComposerCard.tsx
+++ b/apps/ui/src/features/coffee-shop/components/customer/OrderComposerCard.tsx
@@ -20,14 +20,14 @@ export function OrderComposerCard(inputProps: OrderComposerCardProps) {
     inputProps;
 
   return (
-    <Card className="w-full border-border">
-      <Card.Header className="border-b-2 border-border bg-card">
+    <Card className="w-full">
+      <Card.Header className="border-b border-border">
         <Text as="h3">Build an order</Text>
         <Text as="p" className="text-sm text-muted-foreground">
-          The form honors the backend’s milk, temperature, and shot limits for each drink.
+          Menu constraints come from the backend.
         </Text>
       </Card.Header>
-      <Card.Content className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_20rem]">
+      <Card.Content className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_18rem]">
         <OrderFields
           draft={draft}
           item={item}

--- a/apps/ui/src/features/coffee-shop/components/customer/OrderFields.tsx
+++ b/apps/ui/src/features/coffee-shop/components/customer/OrderFields.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import { Button } from "#shared/ui/retroui/Button.tsx";
 import { SelectField } from "#shared/ui/SelectField.tsx";
 import { TextField } from "#shared/ui/TextField.tsx";
 import { TextAreaField } from "#shared/ui/TextAreaField.tsx";
@@ -31,6 +32,60 @@ function FieldRow({ children }: { children: ReactNode }) {
   return <div className="grid gap-4 md:grid-cols-2">{children}</div>;
 }
 
+function SizeField({
+  draft,
+  onUpdateDraft,
+}: Pick<CustomizationFieldsProps, "draft" | "onUpdateDraft">) {
+  return (
+    <SelectField
+      label="Size"
+      options={drinkSizes.map((value) => ({
+        label: toLabel(value),
+        value,
+      }))}
+      value={draft.size}
+      onChange={(value) => onUpdateDraft("size", value)}
+    />
+  );
+}
+
+function MilkField({ draft, item, onUpdateDraft }: CustomizationFieldsProps) {
+  return (
+    <SelectField
+      label="Milk"
+      options={item.availableMilks.map((value) => ({ label: toLabel(value), value }))}
+      value={draft.milk}
+      onChange={(value) => onUpdateDraft("milk", value)}
+    />
+  );
+}
+
+function TemperatureField({ draft, item, onUpdateDraft }: CustomizationFieldsProps) {
+  return (
+    <SelectField
+      label="Temperature"
+      options={item.availableTemperatures.map((value) => ({ label: toLabel(value), value }))}
+      value={draft.temperature}
+      onChange={(value) => onUpdateDraft("temperature", value)}
+    />
+  );
+}
+
+function ShotsField({ draft, item, onUpdateDraft }: CustomizationFieldsProps) {
+  return (
+    <TextField
+      disabled={item.kind === "tea"}
+      helperText={item.kind === "tea" ? "Tea stays at zero shots." : `Max ${item.maxShots} shots`}
+      label="Shots"
+      max={item.maxShots}
+      min={0}
+      type="number"
+      value={draft.shots}
+      onChange={(value: string) => onUpdateDraft("shots", Number.parseInt(value || "0", 10) || 0)}
+    />
+  );
+}
+
 function CustomizationFields(inputProps: CustomizationFieldsProps) {
   const { draft, item, onUpdateDraft } = inputProps;
 
@@ -38,49 +93,18 @@ function CustomizationFields(inputProps: CustomizationFieldsProps) {
     <>
       <FieldRow>
         <FieldCell>
-          <SelectField
-            label="Size"
-            options={drinkSizes.map((value) => ({
-              label: toLabel(value),
-              value,
-            }))}
-            value={draft.size}
-            onChange={(value) => onUpdateDraft("size", value)}
-          />
+          <SizeField draft={draft} onUpdateDraft={onUpdateDraft} />
         </FieldCell>
         <FieldCell>
-          <SelectField
-            label="Milk"
-            options={item.availableMilks.map((value) => ({ label: toLabel(value), value }))}
-            value={draft.milk}
-            onChange={(value) => onUpdateDraft("milk", value)}
-          />
+          <MilkField draft={draft} item={item} onUpdateDraft={onUpdateDraft} />
         </FieldCell>
       </FieldRow>
       <FieldRow>
         <FieldCell>
-          <SelectField
-            label="Temperature"
-            options={item.availableTemperatures.map((value) => ({ label: toLabel(value), value }))}
-            value={draft.temperature}
-            onChange={(value) => onUpdateDraft("temperature", value)}
-          />
+          <TemperatureField draft={draft} item={item} onUpdateDraft={onUpdateDraft} />
         </FieldCell>
         <FieldCell>
-          <TextField
-            disabled={item.kind === "tea"}
-            helperText={
-              item.kind === "tea" ? "Tea stays at zero shots." : `Max ${item.maxShots} shots`
-            }
-            label="Shots"
-            max={item.maxShots}
-            min={0}
-            type="number"
-            value={draft.shots}
-            onChange={(value: string) =>
-              onUpdateDraft("shots", Number.parseInt(value || "0", 10) || 0)
-            }
-          />
+          <ShotsField draft={draft} item={item} onUpdateDraft={onUpdateDraft} />
         </FieldCell>
       </FieldRow>
     </>
@@ -92,6 +116,7 @@ export function OrderFields(inputProps: OrderFieldsProps) {
 
   return (
     <div className="grid gap-4">
+      <DrinkPicker menu={menu} selectedDrinkId={draft.drinkId} onSelectDrink={onSelectDrink} />
       <SelectField
         label="Drink"
         options={menu.map((menuItem) => ({ label: menuItem.name, value: menuItem.id }))}
@@ -108,4 +133,27 @@ export function OrderFields(inputProps: OrderFieldsProps) {
       />
     </div>
   );
+}
+
+function DrinkPicker({ menu, selectedDrinkId, onSelectDrink }: DrinkPickerProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      {menu.map((menuItem) => (
+        <Button
+          key={menuItem.id}
+          size="sm"
+          variant={menuItem.id === selectedDrinkId ? "secondary" : "outline"}
+          onClick={() => onSelectDrink(menuItem.id)}
+        >
+          {menuItem.name}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
+interface DrinkPickerProps {
+  menu: readonly MenuItem[];
+  selectedDrinkId: string;
+  onSelectDrink: (drinkId: string) => void;
 }

--- a/apps/ui/src/features/coffee-shop/components/customer/OrderPreview.tsx
+++ b/apps/ui/src/features/coffee-shop/components/customer/OrderPreview.tsx
@@ -1,6 +1,5 @@
-import { Alert } from "#shared/ui/retroui/Alert.tsx";
-import { Badge } from "#shared/ui/retroui/Badge.tsx";
 import { Button } from "#shared/ui/retroui/Button.tsx";
+import { Card } from "#shared/ui/retroui/Card.tsx";
 import { Text } from "#shared/ui/retroui/Text.tsx";
 import { formatPrice } from "#features/coffee-shop/lib/coffee.ts";
 import type { MenuItem, OrderDraft } from "#features/coffee-shop/lib/coffee.ts";
@@ -17,30 +16,26 @@ export function OrderPreview(inputProps: OrderPreviewProps) {
   const { draft, item, pending, priceCents, onSubmit } = inputProps;
 
   return (
-    <Alert variant="solid" className="grid gap-4 p-5">
-      <Badge className="w-fit rounded-none bg-white px-2.5 py-1 text-black" size="sm">
-        Live preview
-      </Badge>
-      <div className="grid gap-2">
-        <Text as="h3">{item.name}</Text>
-        <Text as="p" className="text-sm text-white/80">
-          {draft.size}, {draft.temperature}, {draft.milk} milk, {draft.shots} shot(s)
+    <Card className="bg-background">
+      <Card.Content className="grid gap-4 p-4">
+        <div className="grid gap-2">
+          <Text as="p" className="text-xs text-muted-foreground">
+            Summary
+          </Text>
+          <Text as="h3" className="text-xl font-semibold">
+            {item.name}
+          </Text>
+          <Text as="p" className="text-sm text-muted-foreground">
+            {draft.size}, {draft.temperature}, {draft.milk} milk, {draft.shots} shot(s)
+          </Text>
+        </div>
+        <Text as="h2" className="text-3xl font-semibold">
+          {formatPrice(priceCents)}
         </Text>
-      </div>
-      <Text as="h2" className="text-4xl">
-        {formatPrice(priceCents)}
-      </Text>
-      <Text as="p" className="text-sm text-white/80">
-        Tickets open in the queue instantly and land in the barista board on the right.
-      </Text>
-      <Button
-        disabled={pending}
-        variant="outline"
-        className="justify-center bg-white text-black"
-        onClick={onSubmit}
-      >
-        {pending ? "Sending order…" : "Send to queue"}
-      </Button>
-    </Alert>
+        <Button className="justify-center" disabled={pending} onClick={onSubmit}>
+          {pending ? "Sending order…" : "Send to queue"}
+        </Button>
+      </Card.Content>
+    </Card>
   );
 }

--- a/apps/ui/src/features/coffee-shop/hooks/useCustomerWorkspace.ts
+++ b/apps/ui/src/features/coffee-shop/hooks/useCustomerWorkspace.ts
@@ -18,40 +18,79 @@ function getErrorMessage(...messages: Array<string | undefined>): string | null 
   return messages.find((message) => message !== undefined) ?? null;
 }
 
+function readMutationError(error: unknown): string {
+  return error instanceof Error ? error.message : "Unable to place the order.";
+}
+
+async function submitCustomerOrder(input: {
+  createOrderMutation: ReturnType<typeof useCreateOrderMutation>;
+  draftState: ReturnType<typeof useOrderDraft>;
+  setReceiptOrder: (order: CoffeeOrder | null) => void;
+}): Promise<void> {
+  const { createOrderMutation, draftState, setReceiptOrder } = input;
+
+  if (draftState.draft === null) {
+    return;
+  }
+
+  try {
+    const order = await createOrderMutation.mutateAsync(toPlaceOrderRequest(draftState.draft));
+    draftState.resetDraft();
+    setReceiptOrder(order);
+    toast.success(`Ticket ${order.id} queued for your account.`);
+  } catch (error) {
+    toast.error(readMutationError(error));
+  }
+}
+
+function createSubmitOrderHandler(input: {
+  createOrderMutation: ReturnType<typeof useCreateOrderMutation>;
+  draftState: ReturnType<typeof useOrderDraft>;
+  setReceiptOrder: (order: CoffeeOrder | null) => void;
+}) {
+  return async () => submitCustomerOrder(input);
+}
+
+function useCustomerQueries(viewer: ReturnType<typeof useViewerQuery>["data"]) {
+  const canLoadOrders = viewer !== undefined && isAuthenticatedViewer(viewer);
+  const menuQuery = useMenuQuery();
+  const ordersQuery = useOrdersQuery({ enabled: canLoadOrders });
+
+  return {
+    menu: menuQuery.data ?? [],
+    menuQuery,
+    orders: ordersQuery.data ?? emptyOrders,
+    ordersQuery,
+  };
+}
+
+function getOrderGroups(orders: readonly CoffeeOrder[]) {
+  return {
+    activeOrders: orders.filter(isActiveOrder),
+    historyOrders: orders.filter((order) => !isActiveOrder(order)).reverse(),
+  };
+}
+
 export function useCustomerWorkspace() {
   const viewerQuery = useViewerQuery();
   const viewer = viewerQuery.data ?? anonymousViewer;
-  const canLoadOrders = isAuthenticatedViewer(viewer);
-  const menuQuery = useMenuQuery();
-  const ordersQuery = useOrdersQuery({ enabled: canLoadOrders });
+  const { menu, menuQuery, orders, ordersQuery } = useCustomerQueries(viewerQuery.data);
   const createOrderMutation = useCreateOrderMutation();
   const { theme, toggleTheme } = useThemePreference();
   const [receiptOrder, setReceiptOrder] = useState<CoffeeOrder | null>(null);
-  const menu = menuQuery.data ?? [];
-  const orders = ordersQuery.data ?? emptyOrders;
   const draftState = useOrderDraft(menu);
-  const activeOrders = orders.filter(isActiveOrder);
-  const historyOrders = orders.filter((order) => !isActiveOrder(order)).reverse();
+  const { activeOrders, historyOrders } = getOrderGroups(orders);
   const errorMessage = getErrorMessage(
     viewerQuery.error?.message,
     menuQuery.error?.message,
     ordersQuery.error?.message,
   );
 
-  async function submitOrder(): Promise<void> {
-    if (draftState.draft === null) {
-      return;
-    }
-
-    try {
-      const order = await createOrderMutation.mutateAsync(toPlaceOrderRequest(draftState.draft));
-      draftState.resetDraft();
-      setReceiptOrder(order);
-      toast.success(`Ticket ${order.id} queued for your account.`);
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Unable to place the order.");
-    }
-  }
+  const submitOrder = createSubmitOrderHandler({
+    createOrderMutation,
+    draftState,
+    setReceiptOrder,
+  });
 
   return {
     activeOrders,

--- a/apps/ui/src/features/coffee-shop/hooks/useStaffWorkspace.ts
+++ b/apps/ui/src/features/coffee-shop/hooks/useStaffWorkspace.ts
@@ -52,17 +52,32 @@ function useOrderActionHandler(
   };
 }
 
+function useStaffOrders(input: {
+  selectedOrderId: string | null;
+  viewer: ReturnType<typeof useViewerQuery>["data"];
+}) {
+  const { selectedOrderId, viewer } = input;
+  const canLoadOrders =
+    viewer !== undefined && isAuthenticatedViewer(viewer) && isStaffViewer(viewer);
+  const ordersQuery = useOrdersQuery({ enabled: canLoadOrders });
+  const orders = ordersQuery.data ?? emptyOrders;
+
+  return {
+    orders,
+    ordersQuery,
+    ...getStaffQueueSnapshot(orders, selectedOrderId),
+  };
+}
+
 export function useStaffWorkspace() {
   const viewerQuery = useViewerQuery();
   const viewer = viewerQuery.data ?? anonymousViewer;
-  const canLoadOrders = isAuthenticatedViewer(viewer) && isStaffViewer(viewer);
-  const ordersQuery = useOrdersQuery({ enabled: canLoadOrders });
   const orderActionMutation = useOrderActionMutation();
   const { theme, toggleTheme } = useThemePreference();
   const [selectedOrderId, setSelectedOrderId] = useState<string | null>(null);
-  const orders = ordersQuery.data ?? emptyOrders;
-  const { activeOrders, historyOrders, queueLoad, readyCount, selectedOrder } =
-    getStaffQueueSnapshot(orders, selectedOrderId);
+  const staffOrders = useStaffOrders({ selectedOrderId, viewer: viewerQuery.data });
+  const { activeOrders, historyOrders, orders, ordersQuery, queueLoad, readyCount, selectedOrder } =
+    staffOrders;
   const pendingOrderId = orderActionMutation.variables?.orderId ?? null;
   const errorMessage = getErrorMessage(viewerQuery.error?.message, ordersQuery.error?.message);
   const handleOrderAction = useOrderActionHandler(orderActionMutation, setSelectedOrderId);

--- a/apps/ui/src/shared/hooks/useThemePreference.ts
+++ b/apps/ui/src/shared/hooks/useThemePreference.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 export type ThemePreference = "light" | "dark";
 
@@ -13,19 +13,23 @@ function applyTheme(theme: ThemePreference): void {
   window.localStorage.setItem(storageKey, theme);
 }
 
+function readInitialTheme(): ThemePreference {
+  if (typeof window === "undefined") {
+    return "light";
+  }
+
+  const theme = readStoredTheme();
+  applyTheme(theme);
+  return theme;
+}
+
 export function useThemePreference() {
-  const [theme, setTheme] = useState<ThemePreference>(() => {
-    if (typeof window === "undefined") {
-      return "light";
-    }
-
-    return readStoredTheme();
-  });
-
-  useEffect(() => applyTheme(theme), [theme]);
+  const [theme, setTheme] = useState<ThemePreference>(readInitialTheme);
 
   function toggleTheme(): void {
-    setTheme((currentTheme) => (currentTheme === "light" ? "dark" : "light"));
+    const nextTheme = theme === "light" ? "dark" : "light";
+    applyTheme(nextTheme);
+    setTheme(nextTheme);
   }
 
   return { theme, toggleTheme };

--- a/apps/ui/src/shared/ui/StatusBadge.tsx
+++ b/apps/ui/src/shared/ui/StatusBadge.tsx
@@ -4,11 +4,11 @@ import { getStatusLabel } from "#features/coffee-shop/lib/coffee.ts";
 import type { OrderStatus } from "#features/coffee-shop/lib/coffee.ts";
 
 const badgeClasses: Record<OrderStatus, string> = {
-  pending: "bg-yellow-300 text-yellow-900",
-  brewing: "bg-sky-300 text-sky-950",
-  ready: "bg-green-300 text-green-900",
-  "picked-up": "bg-black text-white",
-  cancelled: "bg-rose-300 text-rose-900",
+  pending: "bg-muted text-muted-foreground",
+  brewing: "bg-amber-100 text-amber-900 dark:bg-amber-900/40 dark:text-amber-100",
+  ready: "bg-emerald-100 text-emerald-900 dark:bg-emerald-900/40 dark:text-emerald-100",
+  "picked-up": "bg-primary text-primary-foreground",
+  cancelled: "bg-red-100 text-red-900 dark:bg-red-900/40 dark:text-red-100",
 };
 
 interface StatusBadgeProps {
@@ -18,7 +18,7 @@ interface StatusBadgeProps {
 export function StatusBadge({ status }: StatusBadgeProps) {
   return (
     <Badge
-      className={cn("rounded-none px-2.5 py-1 uppercase tracking-[0.08em]", badgeClasses[status])}
+      className={cn("rounded-full px-2.5 py-1 text-xs font-medium", badgeClasses[status])}
       size="sm"
     >
       {getStatusLabel(status)}

--- a/apps/ui/src/shared/ui/retroui/Dialog.tsx
+++ b/apps/ui/src/shared/ui/retroui/Dialog.tsx
@@ -10,12 +10,7 @@ const Dialog = ReactDialog.Root;
 const DialogTrigger = ReactDialog.Trigger;
 
 const overlayVariants = cva(
-  ` fixed bg-black/80 font-head
-    data-[state=open]:fade-in-0
-    data-[state=open]:animate-in 
-    data-[state=closed]:animate-out 
-    data-[state=closed]:fade-out-0 
-  `,
+  "fixed bg-black/80 font-head data-[state=open]:fade-in-0 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0",
   {
     variants: {
       variant: {
@@ -45,16 +40,9 @@ const DialogBackdrop = React.forwardRef<HTMLDivElement, IDialogBackgroupProps>(
     );
   },
 );
-DialogBackdrop.displayName = "DialogBackdrop";
 
 const dialogVariants = cva(
-  `fixed left-[50%] top-[50%] z-50 grid rounded overflow-hidden w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border-2 bg-background shadow-lg duration-200 
-  data-[state=open]:animate-in 
-  data-[state=open]:fade-in-0 
-  data-[state=open]:zoom-in-95 
-  data-[state=closed]:animate-out 
-  data-[state=closed]:fade-out-0 
-  data-[state=closed]:zoom-out-95`,
+  "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden rounded border-2 bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95",
   {
     variants: {
       size: {
@@ -99,7 +87,6 @@ const DialogContent = React.forwardRef<HTMLDivElement, IDialogContentProps>(func
     </ReactDialog.Portal>
   );
 });
-DialogContent.displayName = "DialogContent";
 
 type IDialogDescriptionProps = HTMLAttributes<HTMLDivElement>;
 const DialogDescription = ({ children, className, ...props }: IDialogDescriptionProps) => {

--- a/apps/ui/src/shared/ui/retroui/Drawer.tsx
+++ b/apps/ui/src/shared/ui/retroui/Drawer.tsx
@@ -1,28 +1,25 @@
-import * as React from "react";
+import type { ComponentProps } from "react";
 import { Drawer as DrawerPrimitive } from "vaul";
 
 import { cn } from "#shared/lib/utils.ts";
 
-function Drawer({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Root>) {
+function Drawer({ ...props }: ComponentProps<typeof DrawerPrimitive.Root>) {
   return <DrawerPrimitive.Root data-slot="drawer" {...props} />;
 }
 
-function DrawerTrigger({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Trigger>) {
+function DrawerTrigger({ ...props }: ComponentProps<typeof DrawerPrimitive.Trigger>) {
   return <DrawerPrimitive.Trigger data-slot="drawer-trigger" {...props} />;
 }
 
-function DrawerPortal({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Portal>) {
+function DrawerPortal({ ...props }: ComponentProps<typeof DrawerPrimitive.Portal>) {
   return <DrawerPrimitive.Portal data-slot="drawer-portal" {...props} />;
 }
 
-function DrawerClose({ ...props }: React.ComponentProps<typeof DrawerPrimitive.Close>) {
+function DrawerClose({ ...props }: ComponentProps<typeof DrawerPrimitive.Close>) {
   return <DrawerPrimitive.Close data-slot="drawer-close" {...props} />;
 }
 
-function DrawerOverlay({
-  className,
-  ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Overlay>) {
+function DrawerOverlay({ className, ...props }: ComponentProps<typeof DrawerPrimitive.Overlay>) {
   return (
     <DrawerPrimitive.Overlay
       data-slot="drawer-overlay"
@@ -39,7 +36,7 @@ function DrawerContent({
   className,
   children,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Content>) {
+}: ComponentProps<typeof DrawerPrimitive.Content>) {
   return (
     <DrawerPortal data-slot="drawer-portal">
       <DrawerOverlay />
@@ -62,7 +59,7 @@ function DrawerContent({
   );
 }
 
-function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DrawerHeader({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="drawer-header"
@@ -75,7 +72,7 @@ function DrawerHeader({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
+function DrawerFooter({ className, ...props }: ComponentProps<"div">) {
   return (
     <div
       data-slot="drawer-footer"
@@ -85,7 +82,7 @@ function DrawerFooter({ className, ...props }: React.ComponentProps<"div">) {
   );
 }
 
-function DrawerTitle({ className, ...props }: React.ComponentProps<typeof DrawerPrimitive.Title>) {
+function DrawerTitle({ className, ...props }: ComponentProps<typeof DrawerPrimitive.Title>) {
   return (
     <DrawerPrimitive.Title
       data-slot="drawer-title"
@@ -98,7 +95,7 @@ function DrawerTitle({ className, ...props }: React.ComponentProps<typeof Drawer
 function DrawerDescription({
   className,
   ...props
-}: React.ComponentProps<typeof DrawerPrimitive.Description>) {
+}: ComponentProps<typeof DrawerPrimitive.Description>) {
   return (
     <DrawerPrimitive.Description
       data-slot="drawer-description"

--- a/apps/ui/src/shared/ui/retroui/Label.tsx
+++ b/apps/ui/src/shared/ui/retroui/Label.tsx
@@ -1,14 +1,11 @@
-import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { cva } from "class-variance-authority";
+import type { ComponentProps } from "react";
 
 import { cn } from "#shared/lib/utils.ts";
 
 const labelVariants = cva("leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70");
 
-export const Label = ({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) => (
+export const Label = ({ className, ...props }: ComponentProps<typeof LabelPrimitive.Root>) => (
   <LabelPrimitive.Root className={cn(labelVariants(), className)} {...props} />
 );

--- a/apps/ui/src/shared/ui/retroui/Progress.tsx
+++ b/apps/ui/src/shared/ui/retroui/Progress.tsx
@@ -1,13 +1,13 @@
 "use client";
 
-import * as React from "react";
 import * as ProgressPrimitive from "@radix-ui/react-progress";
+import { forwardRef, type ComponentPropsWithoutRef, type ElementRef } from "react";
 
 import { cn } from "#shared/lib/utils.ts";
 
-const Progress = React.forwardRef<
-  React.ElementRef<typeof ProgressPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
+const Progress = forwardRef<
+  ElementRef<typeof ProgressPrimitive.Root>,
+  ComponentPropsWithoutRef<typeof ProgressPrimitive.Root>
 >(({ className, value, ...props }, ref) => (
   <ProgressPrimitive.Root
     ref={ref}

--- a/apps/ui/src/shared/ui/retroui/Table.tsx
+++ b/apps/ui/src/shared/ui/retroui/Table.tsx
@@ -1,8 +1,13 @@
-import * as React from "react";
+import {
+  forwardRef,
+  type HTMLAttributes,
+  type TdHTMLAttributes,
+  type ThHTMLAttributes,
+} from "react";
 
 import { cn } from "#shared/lib/utils.ts";
 
-const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableElement>>(
+const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElement>>(
   ({ className, ...props }, ref) => (
     <div className="relative h-full w-full overflow-auto">
       <table
@@ -15,39 +20,36 @@ const Table = React.forwardRef<HTMLTableElement, React.HTMLAttributes<HTMLTableE
 );
 Table.displayName = "Table";
 
-const TableHeader = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <thead
-    ref={ref}
-    className={cn("[&_tr]:border-b bg-primary text-primary-foreground font-head", className)}
-    {...props}
-  />
-));
+const TableHeader = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <thead
+      ref={ref}
+      className={cn("[&_tr]:border-b bg-primary text-primary-foreground font-head", className)}
+      {...props}
+    />
+  ),
+);
 TableHeader.displayName = "TableHeader";
 
-const TableBody = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
-));
+const TableBody = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tbody ref={ref} className={cn("[&_tr:last-child]:border-0", className)} {...props} />
+  ),
+);
 TableBody.displayName = "TableBody";
 
-const TableFooter = React.forwardRef<
-  HTMLTableSectionElement,
-  React.HTMLAttributes<HTMLTableSectionElement>
->(({ className, ...props }, ref) => (
-  <tfoot
-    ref={ref}
-    className={cn("border-t bg-accent font-medium [&>tr]:last:border-b-0", className)}
-    {...props}
-  />
-));
+const TableFooter = forwardRef<HTMLTableSectionElement, HTMLAttributes<HTMLTableSectionElement>>(
+  ({ className, ...props }, ref) => (
+    <tfoot
+      ref={ref}
+      className={cn("border-t bg-accent font-medium [&>tr]:last:border-b-0", className)}
+      {...props}
+    />
+  ),
+);
 TableFooter.displayName = "TableFooter";
 
-const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTMLTableRowElement>>(
+const TableRow = forwardRef<HTMLTableRowElement, HTMLAttributes<HTMLTableRowElement>>(
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
@@ -61,39 +63,36 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
 );
 TableRow.displayName = "TableRow";
 
-const TableHead = React.forwardRef<
-  HTMLTableCellElement,
-  React.ThHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <th
-    ref={ref}
-    className={cn(
-      "h-10 md:h-12 px-4 text-left align-middle font-medium text-primary-foreground [&:has([role=checkbox])]:pr-0",
-      className,
-    )}
-    {...props}
-  />
-));
+const TableHead = forwardRef<HTMLTableCellElement, ThHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <th
+      ref={ref}
+      className={cn(
+        "h-10 md:h-12 px-4 text-left align-middle font-medium text-primary-foreground [&:has([role=checkbox])]:pr-0",
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
 TableHead.displayName = "TableHead";
 
-const TableCell = React.forwardRef<
-  HTMLTableCellElement,
-  React.TdHTMLAttributes<HTMLTableCellElement>
->(({ className, ...props }, ref) => (
-  <td
-    ref={ref}
-    className={cn("p-2 md:p-3 align-middle [&:has([role=checkbox])]:pr-0", className)}
-    {...props}
-  />
-));
+const TableCell = forwardRef<HTMLTableCellElement, TdHTMLAttributes<HTMLTableCellElement>>(
+  ({ className, ...props }, ref) => (
+    <td
+      ref={ref}
+      className={cn("p-2 md:p-3 align-middle [&:has([role=checkbox])]:pr-0", className)}
+      {...props}
+    />
+  ),
+);
 TableCell.displayName = "TableCell";
 
-const TableCaption = React.forwardRef<
-  HTMLTableCaptionElement,
-  React.HTMLAttributes<HTMLTableCaptionElement>
->(({ className, ...props }, ref) => (
-  <caption ref={ref} className={cn("my-2 text-sm text-muted-foreground", className)} {...props} />
-));
+const TableCaption = forwardRef<HTMLTableCaptionElement, HTMLAttributes<HTMLTableCaptionElement>>(
+  ({ className, ...props }, ref) => (
+    <caption ref={ref} className={cn("my-2 text-sm text-muted-foreground", className)} {...props} />
+  ),
+);
 TableCaption.displayName = "TableCaption";
 
 const TableObj = Object.assign(Table, {


### PR DESCRIPTION
## Summary
- Redesign the assistant, customer, staff, and agent approval UI around the minimal Paper artboards.
- Keep Retro UI as the component layer while softening cards, buttons, tables, dialogs, drawer, progress, and theme tokens.
- Tighten UI oxlint limits for complexity, file/function length, depth, and statements.
- Ban `useEffect` in the UI workspace through oxlint restricted React imports/properties.
- Split larger view functions into smaller focused components and shared workspace shell helpers.

## Verification
- `bun run --cwd apps/ui lint`
- `bun run --cwd apps/ui typecheck`
- `bun run --cwd apps/ui lint:custom`
- `bun run --cwd apps/ui fmt:check`
- `bun run --cwd apps/ui test`
- `bun run --cwd apps/ui build`
- `bun run fallow:audit`
- pre-push `check-affected`
- `npx -y agent-browser@0.27.0` smoke screenshots for `/`, `/shop`, and `/staff`
