### PR TITLE
chore(prime): publish coffee ordering env 0.1.12

### DIFF
--- a/docs/beanline-prime-intellect-flight-log.md
+++ b/docs/beanline-prime-intellect-flight-log.md
@@ -1046,3 +1046,29 @@ Published `kevinmichaelchen/effect-coffee-ordering@0.1.12` on
 - Caveat: the existing Prime environment still reports `PRIVATE` visibility even
   though the push used `--visibility PUBLIC`; the current CLI exposes no
   separate visibility update command.
+
+### Blocked `0.1.12` Champion Baselines
+
+Attempted fresh hosted baselines for champion adapter
+`rqvfrcdy4xt95oka37b0xjyu` on `0.1.12`.
+
+| Eval id | Split | Status | Result |
+| --- | --- | --- | --- |
+| `jxlbpddxbkkigg0zyjl99ffe` | `hard_eval` | failed before scoring | Hosted eval pulled and installed `effect-coffee-ordering==0.1.12`, then inference returned `404` for `Qwen/Qwen3.5-0.8B:rqvfrcdy4xt95oka37b0xjyu`. |
+| `yf28igow4r0mwwi2ey6bscfe` | `product_readiness` | failed before scoring | Same failure: `0.1.12` installed, but the champion adapter model string was unavailable to hosted inference. |
+| `s4ewj8fmw7muxoqwqb9f8wum` | `hard_eval` | failed before scoring | After the adapter deployed successfully, hosted eval installed `0.1.12` but inference preflight returned a 503 auth-service/model lookup error. |
+| `gvedyecbd8xomrrirltdr6w4` | `product_readiness` | failed before scoring | After the adapter deployed successfully, hosted eval installed `0.1.12` but chat-completions preflight returned a 502 connection error. |
+
+Deployment and inference notes:
+
+- `prime --plain deployments create rqvfrcdy4xt95oka37b0xjyu --yes` failed
+  twice with Prime HTTP 502/proxy registration errors, then later succeeded once
+  `prime --plain inference models` recovered from a 503 auth-service error.
+- `prime --plain deployments delete rqvfrcdy4xt95oka37b0xjyu` failed once with
+  HTTP 500, then succeeded on retry. `prime --plain deployments list --output
+  json` confirmed `deployment_status: "NOT_DEPLOYED"`.
+- Wallet balance remained `$42.26` after the failed hosted evals and unload.
+
+Decision: no promotion and no model-quality conclusion. This is a Prime hosted
+inference/deployment blocker, not evidence that Beanline improved or regressed.
+Retry the same baselines after Prime inference and adapter deployment recover.

--- a/docs/beanline-prime-intellect-flight-log.md
+++ b/docs/beanline-prime-intellect-flight-log.md
@@ -969,6 +969,8 @@ Published environment versions:
   and merge legacy top-level tool args into parsed items.
 - `0.1.11`: tightened the system prompt to prefer the smallest useful tool path
   and avoid menu/options probes before complete one-shot orders.
+- `0.1.12`: published the PR 47 hardening: shared coffee-domain logic, cart id
+  fixes, local tests, and stricter cart tool sequence/count grading.
 
 The live app assistant prompt and SFT corpora were kept aligned with the Prime
 prompt.
@@ -992,7 +994,9 @@ Do not promote any expanded-tool candidate yet. The old champion remains best
 for the old `0.1.5` hard gate, but the expanded tool surface defines a better
 product target and exposes weaknesses in both the 0.8B champion and raw 2B.
 
-Next Prime spend: run the small 0.8B receipt-drill warmup against `0.1.11`.
+Next Prime spend: run fresh hard and product-readiness baselines against
+`0.1.12` before any new training. Only run the small 0.8B receipt-drill warmup
+against `0.1.12` if those baselines support it.
 Promote only if it beats `0.830` hard reward, improves price formatting, keeps
 tool correctness near the old champion, and does not increase verbosity or tool
 overuse.
@@ -1025,3 +1029,20 @@ menu/option tools before complete orders.
 Next direction: do not rerun unchanged. Prefer prompt optimization or SFT on
 the final-response and tool-trajectory corpora, or simplify the tool schema
 further before spending more RL.
+
+### Environment `0.1.12` Publication
+
+Published `kevinmichaelchen/effect-coffee-ordering@0.1.12` on
+2026-05-11 02:06:07 UTC.
+
+- Version id: `aepqx6281krso8wapgeo0tm1`
+- Content hash:
+  `03ec63d33b739383d016885d3860ba2d4ab3fd802d42eae06ce856ae82a4142f`
+- Wheel SHA256:
+  `2bcb56917e4556a9fee3a00cdf28336019d5535c8608339704e1dc920f411fb9`
+- Integration action: `hnig60wrqy8ed6nht2muyt0n`
+- Verification: action logs showed package pull, install/import, and Prime
+  integration tests passing (`4 passed`).
+- Caveat: the existing Prime environment still reports `PRIVATE` visibility even
+  though the push used `--visibility PUBLIC`; the current CLI exposes no
+  separate visibility update command.

--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -31,10 +31,12 @@ Prime CLI rejects it as a `checkpoint_id` for new training runs.
 
 ## Receipt Run
 
-Use the small budget-capped receipt-drill warmup. Environment
-`kevinmichaelchen/effect-coffee-ordering@0.1.11` is published with the expanded
-tool surface, split-specific eval routing, single-item `items_json` tolerance,
-and a direct-order-first prompt.
+Use the small budget-capped receipt-drill warmup only after fresh baselines on
+`kevinmichaelchen/effect-coffee-ordering@0.1.12`. Version `0.1.12` is published
+and contains the PR 47 hardening: shared coffee-domain logic, cart id fixes,
+local tests, stricter cart tool sequence/count grading, the expanded tool
+surface, split-specific eval routing, single-item `items_json` tolerance, and a
+direct-order-first prompt.
 
 ```sh
 cd experiments/prime-intellect/effect-coffee-ordering
@@ -53,9 +55,10 @@ for:
 - pickup timing, customer name, and order notes,
 - concise refusal behavior.
 
-Environment `kevinmichaelchen/effect-coffee-ordering@0.1.11` is published.
-Prime hosted evals confirmed `product_readiness` now runs all 16 examples after
-the `eval_dataset` routing fix.
+Environment `kevinmichaelchen/effect-coffee-ordering@0.1.12` is published and
+should be selected for new hosted baselines, evals, or training. Prime hosted
+evals on earlier versions confirmed `product_readiness` now runs all 16
+examples after the `eval_dataset` routing fix.
 
 Do not rerun `effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml`
 until the receipt drill or a prompt/SFT pass improves direct order behavior.
@@ -96,6 +99,10 @@ instead of `$5.20`, plus repeated menu/option probes.
 Next best action is not another unchanged RL run. Use prompt optimization or SFT
 on the final-response and tool-trajectory corpora, or simplify the tool schema
 further so 0.8B has fewer equivalent ways to express one order.
+
+Before any new hosted training spend, run fresh hosted baselines on
+`kevinmichaelchen/effect-coffee-ordering@0.1.12`; the warmup configs now pin
+that version.
 
 Inspect the stopped run:
 

--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -132,8 +132,7 @@ prime --plain eval run kevinmichaelchen/effect-coffee-ordering \
   --num-examples 8 \
   --rollouts-per-example 2 \
   --max-tokens 256 \
-  --temperature 0.4 \
-  --abbreviated-summary
+  --temperature 0.4
 
 prime --plain eval run kevinmichaelchen/effect-coffee-ordering \
   --hosted \
@@ -142,15 +141,24 @@ prime --plain eval run kevinmichaelchen/effect-coffee-ordering \
   --num-examples 16 \
   --rollouts-per-example 2 \
   --max-tokens 256 \
-  --temperature 0.4 \
-  --abbreviated-summary
+  --temperature 0.4
 
 prime --plain eval get <eval_id> --output json
 prime --plain deployments delete <candidate_adapter_id>
 ```
 
+The current Prime CLI rejects `--abbreviated-summary`, so do not include it.
 The explicit `--env-args '{"split":"hard_eval"}'` matters. Without it, ad hoc
-evals can fall back to the environment default split.
+evals can fall back to the environment default split. Hosted evals currently
+resolve the latest published environment even when the command includes
+`@0.1.12`, so verify `version_id` in `prime --plain eval get <eval_id>
+--output json`.
+
+Current hosted blocker: fresh champion eval attempts on `0.1.12` reached and
+installed the `0.1.12` package, but failed before scoring. Initial attempts saw
+the undeployed adapter as unavailable; after deployment recovered, follow-up
+evals still failed during Prime inference preflight with 503/502 errors. Retry
+after Prime inference is stable, and unload the adapter after the evals finish.
 
 ## Promote Only If
 

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.11 before launching this.
+# Publish the checked-in environment as version 0.1.12 before launching this.
 # This broadens training from receipt formatting into cashier product behavior.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.11"
+version = "0.1.12"
 args = { split = "product_readiness" }
 
 [val]
@@ -40,7 +40,7 @@ eval_base_model = false
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-hard-eval"
-version = "0.1.11"
+version = "0.1.12"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
@@ -48,7 +48,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-product-readiness"
-version = "0.1.11"
+version = "0.1.12"
 args = { split = "product_readiness" }
 num_examples = 16
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.11 before launching this.
+# Publish the checked-in environment as version 0.1.12 before launching this.
 # This is the deterministic fallback if hosted SFT is still unavailable.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.11"
+version = "0.1.12"
 args = { split = "receipt_drill" }
 
 [val]
@@ -39,7 +39,7 @@ eval_base_model = false
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.11"
+version = "0.1.12"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
@@ -2,7 +2,7 @@
 name = "effect-coffee-ordering"
 description = "Tool-use environment for training coffee-shop ordering assistants."
 tags = ["tool-use", "coffee", "ordering", "train", "eval"]
-version = "0.1.11"
+version = "0.1.12"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@3b77145e14a9bcdaf180a49e7df97dbf2d7bb150",


### PR DESCRIPTION
ELI5: This PR packages the next coffee-ordering training environment and writes down what happened when we tried to baseline it. Think of it as labeling a new practice test and keeping the scorecard next to it.

Why this is valuable:
- Keeps the model work reproducible instead of relying on memory from a local run.
- Records the hosted baseline blocker so we do not waste time or credits rerunning the same broken path.
- Gives later PRs a documented starting point for the confirmation/receipt work.

What changed:
- Published the environment metadata for `effect-coffee-ordering@0.1.12`.
- Updated Prime warmup configs and `NEXT_STEPS.md` around the blocked baseline path.
- Recorded the result in the Prime flight log.

Verification:
- The environment/config files pin the intended version.
- The flight log and `NEXT_STEPS.md` capture the hosted baseline/blocker evidence for the next run.
