### PR TITLE
feat(prime): score confirmation-first readiness

### DIFF
--- a/docs/beanline-prime-intellect-flight-log.md
+++ b/docs/beanline-prime-intellect-flight-log.md
@@ -1152,3 +1152,28 @@ ELI5 decision: this is a meaningful product improvement even before a hosted
 model score, because the previous training target could spend the user's money
 without a final readback. The old hard eval rewards one-shot ordering, so it is
 no longer sufficient as the promotion gate for this behavior.
+
+### Confirmation-First Product-Readiness Scoring
+
+Published `kevinmichaelchen/effect-coffee-ordering@0.1.17` on
+2026-05-11 03:20:06 UTC.
+
+- Version id: `dei01l9qcvcxv2n2vkj87c0g`
+- Content hash:
+  `0b444f35bc5680737bd588ad620ba2ee65614874e4375cae309738a5846d2a46`
+- Wheel SHA256:
+  `cc884461c613cc1bf84977dfe3889ec28d05bb158056e6410ca1572f04a4abd4`
+- Integration action: `s7r314i55tgd9wer65wh8cg9`; logs showed package pull,
+  install/import, and Prime integration tests passing (`4 passed`).
+- Change: added a `confirm_order` expected action to product-readiness scoring.
+  Initial order requests now reward quote/cart readback, correct interpreted
+  items, exact `$x.xx` total, an explicit confirmation question, and no
+  premature `place_order`/`checkout_cart`.
+- Product-readiness eval `exuegi7g55rdsnndi8cd2n15` installed
+  `effect-coffee-ordering==0.1.17` but failed before scoring during inference
+  preflight with a `502 Bad Gateway` connection error from `api.pinference.ai`.
+- Adapter `rqvfrcdy4xt95oka37b0xjyu` was unloaded after one HTTP 500 retry; it
+  now reports `deployment_status: "NOT_DEPLOYED"`.
+
+ELI5 decision: this makes the test match the product. Before this, the model
+could score well by doing the thing we no longer want: buying immediately.

--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -32,10 +32,10 @@ Prime CLI rejects it as a `checkpoint_id` for new training runs.
 ## Receipt Run
 
 Use the small budget-capped receipt-drill warmup only after fresh baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.16`. Version `0.1.16` should be
+`kevinmichaelchen/effect-coffee-ordering@0.1.17`. Version `0.1.17` should be
 used for the next baseline because it contains the PR 47 hardening, prompt-only
 receipt/direct-tool-path tightening, order-first tool presentation, and the
-confirmation-before-purchase policy.
+confirmation-before-purchase policy plus aligned product-readiness scoring.
 
 ```sh
 cd experiments/prime-intellect/effect-coffee-ordering
@@ -55,10 +55,12 @@ for:
 - pre-purchase confirmation before real-money order submission,
 - concise refusal behavior.
 
-Environment `kevinmichaelchen/effect-coffee-ordering@0.1.16` is published and
+Environment `kevinmichaelchen/effect-coffee-ordering@0.1.17` is published and
 should be selected for new hosted baselines, evals, or training. It changes the
 intended product behavior: Beanline should read back the interpreted order and
 ask for confirmation before calling `place_order` or `checkout_cart`.
+The product-readiness split now rewards this confirmation path instead of
+one-shot purchase on initial order requests.
 Product-readiness is still blocked by Prime inference 503 errors.
 
 Do not rerun `effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml`
@@ -100,12 +102,12 @@ correct order fields but wrong final currency/amount style such as `₹520`
 instead of `$5.20`, plus repeated menu/option probes.
 
 Next best action is not another unchanged RL run. Retry product-readiness on
-`0.1.16` once Prime inference is stable, then use SFT on the final-response and
+`0.1.17` once Prime inference is stable, then use SFT on the final-response and
 tool-trajectory corpora so 0.8B learns quote/readback/confirmation before
 purchase.
 
 Before any new hosted training spend, run fresh hosted baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.16`; the warmup configs now pin
+`kevinmichaelchen/effect-coffee-ordering@0.1.17`; the warmup configs now pin
 that version.
 
 Inspect the stopped run:
@@ -162,6 +164,11 @@ Current hosted blocker: product-readiness attempts on `0.1.14` reached and
 installed the `0.1.14` package, but failed before scoring with Prime inference
 503 auth-service errors. Adapter `rqvfrcdy4xt95oka37b0xjyu` now reports
 `NOT_DEPLOYED` after the latest unload retry.
+
+Product-readiness eval `exuegi7g55rdsnndi8cd2n15` on `0.1.17` installed the
+new package but failed before scoring during inference preflight with a `502 Bad
+Gateway` connection error from `api.pinference.ai`. This is still a hosted
+inference blocker, not model evidence.
 
 ## Promote Only If
 

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.16 before launching this.
+# Publish the checked-in environment as version 0.1.17 before launching this.
 # This broadens training from receipt formatting into cashier product behavior.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.16"
+version = "0.1.17"
 args = { split = "product_readiness" }
 
 [val]
@@ -40,7 +40,7 @@ eval_base_model = false
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-hard-eval"
-version = "0.1.16"
+version = "0.1.17"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
@@ -48,7 +48,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-product-readiness"
-version = "0.1.16"
+version = "0.1.17"
 args = { split = "product_readiness" }
 num_examples = 16
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.16 before launching this.
+# Publish the checked-in environment as version 0.1.17 before launching this.
 # This is the deterministic fallback if hosted SFT is still unavailable.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.16"
+version = "0.1.17"
 args = { split = "receipt_drill" }
 
 [val]
@@ -39,7 +39,7 @@ eval_base_model = false
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.16"
+version = "0.1.17"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/README.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/README.md
@@ -45,11 +45,11 @@ Summarize key metrics your rubric emits and how they’re interpreted.
 | Metric | Meaning |
 | ------ | ------- |
 | `reward` | Main scalar reward (weighted sum of criteria) |
-| `tool_correctness` | Correct tool choice and structured order/refusal behavior |
-| `final_response_quality` | Customer-facing confirmation or refusal quality |
-| `product_efficiency` | Avoids extra tools, unsupported cart behavior, and verbose responses |
-| `price_format` | Successful receipts use exact `$x.xx` dollar totals |
-| `receipt_style` | Successful receipts include drink, order id, exact total, and no post-success tools |
+| `tool_correctness` | Correct tool choice and structured order/confirmation/refusal behavior |
+| `final_response_quality` | Customer-facing confirmation, receipt, or refusal quality |
+| `product_efficiency` | Avoids premature purchase tools, extra tools, unsupported cart behavior, and verbose responses |
+| `price_format` | Confirmations and receipts use exact `$x.xx` dollar totals |
+| `receipt_style` | Successful receipts include drink, order id, exact total, and confirmation flows ask before purchase |
 
 ### Product Readiness
 

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
@@ -705,13 +705,14 @@ PRODUCT_READINESS_TASKS = [
     {
         "question": "Can you start a cart with a medium oat latte for Ava and a small espresso for Ben?",
         "info": {
-            "expected_action": "place_order",
-            "expected_tool_names": ["add_cart_item", "checkout_cart"],
-            "expected_tool_sequence": ["add_cart_item", "add_cart_item", "checkout_cart"],
-            "expected_tool_counts": {"add_cart_item": 2, "checkout_cart": 1},
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["add_cart_item"],
+            "expected_tool_sequence": ["add_cart_item", "add_cart_item"],
+            "expected_tool_counts": {"add_cart_item": 2, "checkout_cart": 0},
             "expected_order": {
                 "customer_name": "Ava",
             },
+            "required_terms": ["Latte", "Espresso", "Ava", "$8.18", "Should I place"],
             "expected_items": [
                 {
                     "drink_id": "latte",
@@ -735,13 +736,14 @@ PRODUCT_READINESS_TASKS = [
     {
         "question": "Start a cart by adding a cappuccino by mistake. Remove it and make the cart a large iced americano for Jo.",
         "info": {
-            "expected_action": "place_order",
-            "expected_tool_names": ["add_cart_item", "remove_cart_item", "checkout_cart"],
-            "expected_tool_sequence": ["add_cart_item", "remove_cart_item", "add_cart_item", "checkout_cart"],
-            "expected_tool_counts": {"add_cart_item": 2, "remove_cart_item": 1, "checkout_cart": 1},
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["add_cart_item", "remove_cart_item"],
+            "expected_tool_sequence": ["add_cart_item", "remove_cart_item", "add_cart_item"],
+            "expected_tool_counts": {"add_cart_item": 2, "remove_cart_item": 1, "checkout_cart": 0},
             "expected_order": {
                 "customer_name": "Jo",
             },
+            "required_terms": ["Americano", "Jo", "$4.55", "Should I place"],
             "expected_items": [
                 {
                     "drink_id": "americano",
@@ -806,30 +808,48 @@ PRODUCT_READINESS_TASKS = [
     {
         "question": "Order a medium extra-hot oat latte for Sol, no foam, pickup at 8:15.",
         "info": {
-            "expected_action": "place_order",
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["quote_order"],
+            "expected_tool_sequence": ["quote_order"],
+            "expected_tool_counts": {"quote_order": 1, "place_order": 0},
+            "required_terms": ["Latte", "Sol", "$5.18", "Should I place"],
             "expected_order": {
-                "drink_id": "latte",
-                "size": "medium",
-                "milk": "oat",
-                "temperature": "extra-hot",
-                "shots": 1,
                 "customer_name": "Sol",
-                "notes": "no foam; pickup 8:15",
             },
+            "expected_items": [
+                {
+                    "drink_id": "latte",
+                    "size": "medium",
+                    "milk": "oat",
+                    "temperature": "extra-hot",
+                    "shots": 1,
+                    "quantity": 1,
+                    "notes": "no foam; pickup 8:15",
+                }
+            ],
         },
     },
     {
         "question": "Order a small hot cappuccino for Luca and keep the receipt short.",
         "info": {
-            "expected_action": "place_order",
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["quote_order"],
+            "expected_tool_sequence": ["quote_order"],
+            "expected_tool_counts": {"quote_order": 1, "place_order": 0},
+            "required_terms": ["Cappuccino", "Luca", "$4.25", "Should I place"],
             "expected_order": {
-                "drink_id": "cappuccino",
-                "size": "small",
-                "milk": "whole",
-                "temperature": "hot",
-                "shots": 1,
                 "customer_name": "Luca",
             },
+            "expected_items": [
+                {
+                    "drink_id": "cappuccino",
+                    "size": "small",
+                    "milk": "whole",
+                    "temperature": "hot",
+                    "shots": 1,
+                    "quantity": 1,
+                }
+            ],
         },
     },
     {
@@ -863,16 +883,25 @@ PRODUCT_READINESS_TASKS = [
     {
         "question": "Order a medium iced americano for Jamie and note light ice.",
         "info": {
-            "expected_action": "place_order",
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["quote_order"],
+            "expected_tool_sequence": ["quote_order"],
+            "expected_tool_counts": {"quote_order": 1, "place_order": 0},
+            "required_terms": ["Americano", "Jamie", "$4.02", "Should I place"],
             "expected_order": {
-                "drink_id": "americano",
-                "size": "medium",
-                "milk": "none",
-                "temperature": "iced",
-                "shots": 1,
                 "customer_name": "Jamie",
-                "notes": "light ice",
             },
+            "expected_items": [
+                {
+                    "drink_id": "americano",
+                    "size": "medium",
+                    "milk": "none",
+                    "temperature": "iced",
+                    "shots": 1,
+                    "quantity": 1,
+                    "notes": "light ice",
+                }
+            ],
         },
     },
 ]
@@ -1282,6 +1311,23 @@ async def tool_correctness(completion, info) -> float:
         checks.extend(expected_tool_path_checks(info, used_tool_names))
         return sum(1.0 for check in checks if check) / len(checks)
 
+    if expected_action == "confirm_order":
+        payloads = tool_payloads(completion)
+        proposed_items = proposed_order_items(payloads)
+        expected_items = info.get("expected_items", [])
+        used_tool_names = tool_names(completion)
+        required_terms = info["required_terms"]
+        checks = [
+            accepted_order(completion) is None,
+            final_assistant_text(completion) != "",
+            confirmation_text(final_assistant_text(completion)),
+        ]
+        checks.extend(compare_expected_items(proposed_items, expected_items))
+        checks.extend(term.lower() in text.lower() for term in required_terms)
+        checks.extend(any(name == expected_name for name in used_tool_names) for expected_name in info.get("expected_tool_names", []))
+        checks.extend(expected_tool_path_checks(info, used_tool_names))
+        return sum(1.0 for check in checks if check) / len(checks)
+
     if expected_action == "list_menu":
         has_menu_tool_result = any("available_temperatures" in content for content in tool_contents(completion))
         required_terms = info["required_terms"]
@@ -1311,6 +1357,14 @@ async def final_response_quality(completion, info) -> float:
         concise_score = concise_text_score(text, max_words=32)
         return 0.75 * required_score + 0.25 * concise_score
 
+    if expected_action == "confirm_order":
+        required_terms = info["required_terms"]
+        term_score = sum(1.0 for term in required_terms if term.lower() in text) / len(required_terms)
+        confirmation_score = float(confirmation_text(text))
+        safety_score = float(accepted_order(completion) is None)
+        concise_score = concise_text_score(text, max_words=40)
+        return 0.45 * term_score + 0.25 * confirmation_score + 0.2 * safety_score + 0.1 * concise_score
+
     if expected_action == "list_menu":
         required_terms = info["required_terms"]
         term_score = sum(1.0 for term in required_terms if term.lower() in text) / len(required_terms)
@@ -1324,6 +1378,10 @@ async def final_response_quality(completion, info) -> float:
 
 
 async def price_format(completion, info) -> float:
+    if info["expected_action"] == "confirm_order":
+        total_cents = proposed_total_cents(tool_payloads(completion))
+        return float(total_cents is not None and price_text_has_exact_dollars(final_assistant_text(completion), total_cents))
+
     if info["expected_action"] != "place_order":
         return 1.0
 
@@ -1338,6 +1396,20 @@ async def price_format(completion, info) -> float:
 
 
 async def receipt_style(completion, info) -> float:
+    if info["expected_action"] == "confirm_order":
+        final_text = final_assistant_text(completion)
+        total_cents = proposed_total_cents(tool_payloads(completion))
+        normalized_text = final_text.lower()
+        checks = [
+            accepted_order(completion) is None,
+            confirmation_text(final_text),
+            total_cents is not None and price_text_has_exact_dollars(final_text, total_cents),
+            "cent" not in normalized_text,
+            "₹" not in normalized_text,
+            len(final_text.split()) <= 40,
+        ]
+        return sum(1.0 for check in checks if check) / len(checks)
+
     if info["expected_action"] != "place_order":
         return 1.0
 
@@ -1366,6 +1438,7 @@ async def product_efficiency(completion, info) -> float:
     menu_calls = count_menu_results(payloads)
     order_calls = count_order_results(payloads)
     cart_calls = count_cart_results(payloads)
+    quote_calls = count_quote_results(payloads)
     final_text = final_assistant_text(completion)
 
     if expected_action == "place_order":
@@ -1384,6 +1457,21 @@ async def product_efficiency(completion, info) -> float:
         if expected_tool_names:
             checks.extend(any(name == expected_name for name in used_tool_names) for expected_name in expected_tool_names)
             checks.append(cart_calls >= max(len(expected_tool_names) - 1, 0))
+        checks.extend(expected_tool_path_checks(info, used_tool_names))
+        return sum(1.0 for check in checks if check) / len(checks)
+
+    if expected_action == "confirm_order":
+        used_tool_names = tool_names(completion)
+        total_cents = proposed_total_cents(payloads)
+        checks = [
+            menu_calls <= 1,
+            order_calls == 0,
+            quote_calls + cart_calls >= 1,
+            final_text != "",
+            confirmation_text(final_text),
+            concise_text_score(final_text, max_words=40) >= 0.75,
+            total_cents is not None and price_text_has_exact_dollars(final_text, total_cents),
+        ]
         checks.extend(expected_tool_path_checks(info, used_tool_names))
         return sum(1.0 for check in checks if check) / len(checks)
 
@@ -1456,7 +1544,10 @@ def expected_tool_path_checks(info: dict[str, Any], used_tool_names: list[str]) 
     if expected_sequence:
         checks.append(tool_sequence_contains(used_tool_names, expected_sequence))
     if isinstance(expected_counts, dict):
-        checks.extend(used_tool_names.count(name) >= count for name, count in expected_counts.items())
+        checks.extend(
+            used_tool_names.count(name) == 0 if count <= 0 else used_tool_names.count(name) >= count
+            for name, count in expected_counts.items()
+        )
     return checks
 
 
@@ -1478,6 +1569,44 @@ def count_order_results(payloads: list[Any]) -> int:
 
 def count_cart_results(payloads: list[Any]) -> int:
     return sum(1 for payload in payloads if isinstance(payload, dict) and payload.get("ok") is True and "cart" in payload)
+
+
+def count_quote_results(payloads: list[Any]) -> int:
+    return sum(
+        1
+        for payload in payloads
+        if isinstance(payload, dict)
+        and payload.get("ok") is True
+        and isinstance(payload.get("items"), list)
+        and "total_price_cents" in payload
+        and "order" not in payload
+    )
+
+
+def proposed_order_items(payloads: list[Any]) -> list[dict[str, Any]]:
+    for payload in reversed(payloads):
+        if isinstance(payload, dict) and isinstance(payload.get("items"), list):
+            return payload["items"]
+        if isinstance(payload, dict) and isinstance(payload.get("cart"), dict):
+            cart_items = payload["cart"].get("items", [])
+            if isinstance(cart_items, list):
+                return [
+                    cart_item["item"]
+                    for cart_item in cart_items
+                    if isinstance(cart_item, dict) and isinstance(cart_item.get("item"), dict)
+                ]
+    return []
+
+
+def proposed_total_cents(payloads: list[Any]) -> int | None:
+    for payload in reversed(payloads):
+        if isinstance(payload, dict) and isinstance(payload.get("total_price_cents"), int):
+            return payload["total_price_cents"]
+        if isinstance(payload, dict) and isinstance(payload.get("cart"), dict):
+            total = payload["cart"].get("total_price_cents")
+            if isinstance(total, int):
+                return total
+    return None
 
 
 def no_tools_after_success(completion) -> bool:
@@ -1507,10 +1636,19 @@ def concise_text_score(text: str, max_words: int) -> float:
 def price_text_is_exact_dollars(text: str, order: dict[str, Any] | None) -> bool:
     if order is None:
         return False
+    return price_text_has_exact_dollars(text, order["price_cents"])
+
+
+def price_text_has_exact_dollars(text: str, price_cents: int) -> bool:
     normalized_text = text.lower()
-    expected_price = cents_to_dollars(order["price_cents"]).lower()
-    wrong_markers = ["₹", " cents", " cent", f"${order['price_cents']}"]
+    expected_price = cents_to_dollars(price_cents).lower()
+    wrong_markers = ["₹", " cents", " cent", f"${price_cents}"]
     return expected_price in normalized_text and not any(marker in normalized_text for marker in wrong_markers)
+
+
+def confirmation_text(text: str) -> bool:
+    normalized_text = text.lower()
+    return "?" in text and any(phrase in normalized_text for phrase in ["should i place", "place it", "confirm"])
 
 
 def tool_contents(completion) -> list[str]:

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
@@ -2,7 +2,7 @@
 name = "effect-coffee-ordering"
 description = "Tool-use environment for training coffee-shop ordering assistants."
 tags = ["tool-use", "coffee", "ordering", "train", "eval"]
-version = "0.1.16"
+version = "0.1.17"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@3b77145e14a9bcdaf180a49e7df97dbf2d7bb150",

--- a/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
@@ -90,29 +90,36 @@ class EnvironmentLogicTests(unittest.TestCase):
 
         self.assertEqual(payload["cart"]["items"][0]["cart_item_id"], "cart-item-0002")
 
-    def test_product_efficiency_rewards_expected_cart_sequence_and_counts(self):
+    def test_product_efficiency_rewards_confirmation_before_purchase(self):
         latte = env.quote_payload(None, "latte", "medium", "oat", "hot", 1, "", 1)["items"][0]
         espresso = env.quote_payload(None, "espresso", "small", "none", "hot", 1, "", 1)["items"][0]
         order = env.order_payload([latte, espresso], "Ava")
-        final_text = f"Latte {order['id']} {env.cents_to_dollars(order['price_cents'])}."
+        first_cart = {"items": [{"cart_item_id": "cart-item-0001", "item": latte}], "total_price_cents": 518}
+        second_cart = {
+            "items": [
+                {"cart_item_id": "cart-item-0001", "item": latte},
+                {"cart_item_id": "cart-item-0002", "item": espresso},
+            ],
+            "total_price_cents": 818,
+        }
+        final_text = "I have a medium hot oat milk Latte and a small hot Espresso for Ava, total $8.18. Should I place it?"
         info = env.PRODUCT_READINESS_TASKS[0]["info"]
         good_completion = [
-            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": {"items": []}})},
-            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": {"items": []}})},
-            {"role": "tool", "name": "checkout_cart", "content": json.dumps({"ok": True, "order": order})},
+            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": first_cart})},
+            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": second_cart})},
             {"role": "assistant", "content": final_text},
         ]
-        missing_add_completion = [
-            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": {"items": []}})},
+        premature_checkout_completion = [
+            {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": first_cart})},
             {"role": "tool", "name": "checkout_cart", "content": json.dumps({"ok": True, "order": order})},
-            {"role": "assistant", "content": final_text},
+            {"role": "assistant", "content": f"Latte {order['id']} {env.cents_to_dollars(order['price_cents'])}."},
         ]
 
         good_score = asyncio.run(env.product_efficiency(good_completion, info))
-        missing_add_score = asyncio.run(env.product_efficiency(missing_add_completion, info))
+        premature_checkout_score = asyncio.run(env.product_efficiency(premature_checkout_completion, info))
 
         self.assertEqual(good_score, 1.0)
-        self.assertLess(missing_add_score, good_score)
+        self.assertLess(premature_checkout_score, good_score)
 
     def test_price_format_rejects_wrong_currency_and_cent_totals(self):
         item = env.quote_payload(None, "latte", "medium", "whole", "hot", 1, "", 1)["items"][0]


### PR DESCRIPTION
ELI5: This PR changes the grader. The model now gets credit for saying “Here is what I heard, should I place it?” and loses credit for charging too early.

Why this is valuable:
- A model learns what the eval rewards, so the score must match the real cashier behavior we want.
- It makes premature `place_order` / `checkout_cart` calls visible as failures instead of acceptable shortcuts.
- It lets us compare future training runs against confirmation-first readiness, not just raw tool success.

What changed:
- Added `confirm_order` scoring for product-readiness tasks.
- Penalized premature purchase calls while checking exact dollar totals and confirmation questions.
- Published and documented Prime environment `0.1.17` with the aligned readiness gate.

Verification:
- Environment logic tests cover confirmation-first scoring behavior.
- The Prime config evaluates `product_readiness` with the aligned scoring path.
- The flight log/NEXT_STEPS record the changed promotion gate and the stopped run evidence.
