### PR TITLE
feat(beanline): gate purchases on pending confirmation

### DIFF
--- a/apps/backend/src/cloudflare/mcp-miniflare-worker.test.ts
+++ b/apps/backend/src/cloudflare/mcp-miniflare-worker.test.ts
@@ -51,6 +51,10 @@ const ToolCallOrderResponseSchema = Schema.Struct({
   }),
 });
 
+const ToolCallResponseSchema = Schema.Struct({
+  isError: Schema.optionalKey(Schema.Boolean),
+});
+
 const ResourceReadResponseSchema = Schema.Struct({
   contents: Schema.Array(
     Schema.Struct({
@@ -83,12 +87,19 @@ const initializeClient = (request: McpRequest) =>
   });
 
 const placeLatteOrder = (request: McpRequest) =>
-  request(ToolCallOrderResponseSchema, "tools/call", {
-    name: "place_order",
-    arguments: {
+  Effect.gen(function* () {
+    const orderInput = {
       customerName: "Avery",
       items: [{ drinkId: "latte", size: "medium" }],
-    },
+    };
+    yield* request(ToolCallResponseSchema, "tools/call", {
+      name: "prepare_order_confirmation",
+      arguments: { items: orderInput.items },
+    });
+    return yield* request(ToolCallOrderResponseSchema, "tools/call", {
+      name: "place_order",
+      arguments: orderInput,
+    });
   });
 
 const verifyCatalogSurface = (request: McpRequest) =>

--- a/apps/backend/test/application-use-cases/cart.test.ts
+++ b/apps/backend/test/application-use-cases/cart.test.ts
@@ -12,6 +12,7 @@ import { moneyToCents } from "@effect-coffee-shop/coffee-core/domain/money";
 import { QuoteOrderRequestSchema } from "@effect-coffee-shop/coffee-core/application/contracts";
 import {
   addCartItem,
+  checkoutConfirmedCart,
   checkoutCart,
   clearCart,
   getCart,
@@ -20,6 +21,7 @@ import {
   listOrders,
   prepareCartConfirmation,
   prepareOrderConfirmation,
+  placeConfirmedOrder,
   quoteOrder,
   removeCartItem,
   updateCartItem,
@@ -92,6 +94,37 @@ describe("cart and order planning", () => {
     }).pipe(provideActor(averyActor), Effect.provide(InMemoryCoffeeAppLive)),
   );
 
+  it.effect("places only the direct order that is pending confirmation", () =>
+    Effect.gen(function* () {
+      yield* prepareOrderConfirmation({
+        items: [{ drinkId: "latte", size: "medium", quantity: 2 }],
+      });
+
+      const order = yield* placeConfirmedOrder({
+        items: [{ drinkId: "latte", size: "medium", quantity: 2 }],
+      });
+      const afterPurchase = yield* getPendingOrderConfirmation();
+
+      assert.strictEqual(order.items.length, 1);
+      assert.strictEqual(order.items[0]?.quantity, 2);
+      assert.deepStrictEqual(afterPurchase, Option.none());
+    }).pipe(provideActor(averyActor), Effect.provide(InMemoryCoffeeAppLive)),
+  );
+
+  it.effect("rejects a changed direct order after confirmation", () =>
+    Effect.gen(function* () {
+      yield* prepareOrderConfirmation({
+        items: [{ drinkId: "latte", size: "medium", quantity: 1 }],
+      });
+
+      const exit = yield* placeConfirmedOrder({
+        items: [{ drinkId: "latte", size: "medium", quantity: 2 }],
+      }).pipe(Effect.exit);
+
+      assert.strictEqual(exit._tag, "Failure");
+    }).pipe(provideActor(averyActor), Effect.provide(InMemoryCoffeeAppLive)),
+  );
+
   it.effect("returns menu item options and defaults", () =>
     Effect.gen(function* () {
       const options = yield* getItemOptions({ drinkId: "cold-brew" });
@@ -148,6 +181,24 @@ describe("cart and order planning", () => {
       assert.strictEqual(confirmation.ownerUserId, "user-avery");
       assert.strictEqual(confirmation.items.length, 1);
       assert.deepStrictEqual(loaded, Option.some(confirmation));
+    }).pipe(provideActor(averyActor), Effect.provide(InMemoryCoffeeAppLive)),
+  );
+
+  it.effect("checks out only the cart that is pending confirmation", () =>
+    Effect.gen(function* () {
+      yield* addCartItem({
+        drinkId: "tea",
+        size: "small",
+        quantity: 2,
+      });
+      yield* prepareCartConfirmation();
+
+      const order = yield* checkoutConfirmedCart({});
+      const afterPurchase = yield* getPendingOrderConfirmation();
+
+      assert.strictEqual(order.items.length, 1);
+      assert.strictEqual(order.items[0]?.quantity, 2);
+      assert.deepStrictEqual(afterPurchase, Option.none());
     }).pipe(provideActor(averyActor), Effect.provide(InMemoryCoffeeAppLive)),
   );
 

--- a/apps/backend/test/integration/llm-mcp-client.test.ts
+++ b/apps/backend/test/integration/llm-mcp-client.test.ts
@@ -17,6 +17,8 @@ const ToolCallOrderResultSchema = Schema.Struct({
   }),
 });
 
+const ToolCallResultSchema = Schema.Struct({});
+
 const llmMcpWorkflow = () =>
   Effect.gen(function* () {
     const request = getClient().request;
@@ -31,13 +33,19 @@ const llmMcpWorkflow = () =>
       },
     });
 
-    // Place order directly with correct parameters
+    const orderInput = {
+      customerName: "Avery",
+      items: [{ drinkId: "latte", size: "medium" }],
+    };
+    yield* request(ToolCallResultSchema, "tools/call", {
+      name: "prepare_order_confirmation",
+      arguments: { items: orderInput.items },
+    });
+
+    // Place order after matching confirmation state exists
     const placeOrderResult = yield* request(ToolCallOrderResultSchema, "tools/call", {
       name: "place_order",
-      arguments: {
-        customerName: "Avery",
-        items: [{ drinkId: "latte", size: "medium" }],
-      },
+      arguments: orderInput,
     });
 
     const orderId = placeOrderResult.structuredContent.id;

--- a/packages/coffee/actions/src/execute.ts
+++ b/packages/coffee/actions/src/execute.ts
@@ -83,7 +83,7 @@ const actionHandlers = {
     app.prepareCartConfirmation().pipe(Effect.map(toPendingOrderConfirmationView)),
   ),
   place_order: runDecodedAction(decodePlaceOrderInput, (app, payload) =>
-    app.placeOrder(payload).pipe(Effect.map(toCoffeeOrderView)),
+    app.placeConfirmedOrder(payload).pipe(Effect.map(toCoffeeOrderView)),
   ),
   get_order: runOrderIdAction((app, orderId) => app.getOrder(orderId)),
   list_orders: runDecodedAction(decodeListOrdersInput, (app, payload) =>
@@ -105,7 +105,7 @@ const actionHandlers = {
   ),
   clear_cart: runEmptyAction((app) => app.clearCart().pipe(Effect.map(toCartView))),
   checkout_cart: runDecodedAction(decodeCheckoutCartInput, (app, payload) =>
-    app.checkoutCart(payload).pipe(Effect.map(toCoffeeOrderView)),
+    app.checkoutConfirmedCart(payload).pipe(Effect.map(toCoffeeOrderView)),
   ),
 } satisfies Record<CoffeeActionName, ActionHandler>;
 

--- a/packages/coffee/assistant/src/handler.ts
+++ b/packages/coffee/assistant/src/handler.ts
@@ -49,6 +49,7 @@ const coffeeAssistantSystemPrompt = [
   "Because orders spend real money, read back the interpreted order and ask for confirmation before purchase.",
   "On an initial order request, do not call place_order or checkout_cart yet; use prepare_order_confirmation for a direct proposed order, or cart tools followed by prepare_cart_confirmation for cart workflows.",
   'Call place_order or checkout_cart only after the user explicitly confirms the final order, such as "yes, place it" or "submit that order".',
+  "Purchase tools require matching pending confirmation state; if the order changed, prepare confirmation again and ask the user to confirm again.",
   "Use list_menu for general menu, substitution, unavailable ingredient, or recommendation questions.",
   "Use get_item_options for a specific drink's defaults and valid choices when the user asks or a drink option is unclear.",
   "Use validate_order or quote_order only when options, price, or defaults are uncertain and you are not ready to create pending confirmation state.",

--- a/packages/coffee/auth/src/agent-auth.test.ts
+++ b/packages/coffee/auth/src/agent-auth.test.ts
@@ -64,10 +64,16 @@ async function placeLatteOrder(db: D1Database, session: AgentSession) {
     appLayer: makeCloudflareCoffeeAppLive(db),
     session,
   });
+  const orderInput = {
+    items: [{ drinkId: "latte", size: "medium" }],
+  };
+  await executeCoffeeAgentCapability({
+    arguments: orderInput,
+    capability: "prepare_order_confirmation",
+    runApp,
+  });
   const result = await executeCoffeeAgentCapability({
-    arguments: {
-      items: [{ drinkId: "latte", size: "medium" }],
-    },
+    arguments: orderInput,
     capability: "place_order",
     runApp,
   });

--- a/packages/coffee/core/src/application/CoffeeOrderApp.ts
+++ b/packages/coffee/core/src/application/CoffeeOrderApp.ts
@@ -40,6 +40,7 @@ import { PendingOrderConfirmationRepository } from "./ports/PendingOrderConfirma
 import {
   cancelOrder,
   addCartItem,
+  checkoutConfirmedCart,
   checkoutCart,
   clearCart,
   getCart,
@@ -49,6 +50,7 @@ import {
   listOrders,
   markReady,
   placeOrder,
+  placeConfirmedOrder,
   pickUpOrder,
   quoteOrder,
   prepareCartConfirmation,
@@ -84,6 +86,12 @@ export class CoffeeOrderApp extends Context.Service<
       AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError
     >;
     readonly placeOrder: (
+      input: PlaceOrderRequest,
+    ) => Effect.Effect<
+      CoffeeOrder,
+      AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError
+    >;
+    readonly placeConfirmedOrder: (
       input: PlaceOrderRequest,
     ) => Effect.Effect<
       CoffeeOrder,
@@ -173,6 +181,12 @@ export class CoffeeOrderApp extends Context.Service<
       CoffeeOrder,
       AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError
     >;
+    readonly checkoutConfirmedCart: (
+      input: CheckoutCartRequest,
+    ) => Effect.Effect<
+      CoffeeOrder,
+      AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError
+    >;
   }
 >()("effect-coffee-shop/application/CoffeeOrderApp") {
   static readonly layer = Layer.effect(
@@ -215,6 +229,16 @@ export class CoffeeOrderApp extends Context.Service<
             Effect.provideService(MenuRepository, menuRepository),
             Effect.provideService(OrderIdGenerator, orderIdGenerator),
             Effect.provideService(OrderRepository, orderRepository),
+          ),
+        placeConfirmedOrder: (input) =>
+          placeConfirmedOrder(input).pipe(
+            Effect.provideService(MenuRepository, menuRepository),
+            Effect.provideService(OrderIdGenerator, orderIdGenerator),
+            Effect.provideService(OrderRepository, orderRepository),
+            Effect.provideService(
+              PendingOrderConfirmationRepository,
+              pendingOrderConfirmationRepository,
+            ),
           ),
         getOrder: (orderId) =>
           getOrder(orderId).pipe(Effect.provideService(OrderRepository, orderRepository)),
@@ -260,6 +284,17 @@ export class CoffeeOrderApp extends Context.Service<
             Effect.provideService(MenuRepository, menuRepository),
             Effect.provideService(OrderIdGenerator, orderIdGenerator),
             Effect.provideService(OrderRepository, orderRepository),
+          ),
+        checkoutConfirmedCart: (input) =>
+          checkoutConfirmedCart(input).pipe(
+            Effect.provideService(CartRepository, cartRepository),
+            Effect.provideService(MenuRepository, menuRepository),
+            Effect.provideService(OrderIdGenerator, orderIdGenerator),
+            Effect.provideService(OrderRepository, orderRepository),
+            Effect.provideService(
+              PendingOrderConfirmationRepository,
+              pendingOrderConfirmationRepository,
+            ),
           ),
       });
     }),

--- a/packages/coffee/core/src/application/use-cases/confirmedPurchase.ts
+++ b/packages/coffee/core/src/application/use-cases/confirmedPurchase.ts
@@ -1,0 +1,151 @@
+import * as Effect from "effect/Effect";
+import * as Equal from "effect/Equal";
+import * as Option from "effect/Option";
+import * as Schema from "effect/Schema";
+import type {
+  DrinkNotFoundError,
+  InvalidOrderInputError,
+} from "@effect-coffee-shop/coffee-core/domain/errors";
+import type { PendingOrderConfirmation } from "@effect-coffee-shop/coffee-core/domain/pending-order-confirmation";
+import type { CoffeeOrder } from "../../domain/order.ts";
+import {
+  AuthenticationRequiredError,
+  requireSignedInActor,
+} from "@effect-coffee-shop/coffee-core/application/CurrentActor";
+import {
+  OrderItemsInputSchema,
+  toOrderQuoteView,
+  type CheckoutCartRequest,
+  type PlaceOrderRequest,
+} from "../contracts.ts";
+import {
+  InternalAppError,
+  internalAppErrorFromPersistence,
+} from "@effect-coffee-shop/coffee-core/application/errors";
+import { CartRepository } from "../ports/CartRepository.ts";
+import { MenuRepository } from "../ports/MenuRepository.ts";
+import { OrderIdGenerator } from "../ports/OrderIdGenerator.ts";
+import { OrderRepository } from "../ports/OrderRepository.ts";
+import { PendingOrderConfirmationRepository } from "../ports/PendingOrderConfirmationRepository.ts";
+import { checkoutCart } from "./cart.ts";
+import { invalidOrderInput, resolveOrderQuote, toOrderItemInput } from "./orderItems.ts";
+import { placeOrder } from "./placeOrder.ts";
+
+const decodeOrderItemsInput = Schema.decodeUnknownEffect(OrderItemsInputSchema);
+
+const loadPendingConfirmation = Effect.fnUntraced(function* (): Effect.fn.Return<
+  PendingOrderConfirmation,
+  AuthenticationRequiredError | InvalidOrderInputError | InternalAppError,
+  PendingOrderConfirmationRepository
+> {
+  const actor = yield* requireSignedInActor();
+  const repository = yield* PendingOrderConfirmationRepository;
+  return yield* repository.getByOwnerUserId(actor.userId).pipe(
+    Effect.mapError(
+      internalAppErrorFromPersistence("Unable to load pending order confirmation right now"),
+    ),
+    Effect.flatMap(
+      Option.match({
+        onNone: () =>
+          Effect.fail(invalidOrderInput("confirm the interpreted order before placing it")),
+        onSome: Effect.succeed,
+      }),
+    ),
+  );
+});
+
+const assertPendingSource = Effect.fnUntraced(function* (
+  confirmation: PendingOrderConfirmation,
+  source: PendingOrderConfirmation["source"],
+): Effect.fn.Return<PendingOrderConfirmation, InvalidOrderInputError> {
+  return yield* Effect.succeed(confirmation).pipe(
+    Effect.filterOrFail(
+      (pending) => pending.source === source,
+      () => invalidOrderInput("confirm the updated order before placing it"),
+    ),
+  );
+});
+
+const assertPendingQuote = Effect.fnUntraced(function* (input: {
+  readonly actual: Parameters<typeof toOrderQuoteView>[0];
+  readonly pending: PendingOrderConfirmation;
+}): Effect.fn.Return<void, InvalidOrderInputError> {
+  const pendingQuote = toOrderQuoteView({
+    items: input.pending.items,
+    totalPrice: input.pending.totalPrice,
+  });
+  const actualQuote = toOrderQuoteView(input.actual);
+
+  yield* Effect.succeed(Equal.equals(actualQuote, pendingQuote)).pipe(
+    Effect.filterOrFail(
+      (matches) => matches,
+      () => invalidOrderInput("confirm the updated order before placing it"),
+    ),
+    Effect.asVoid,
+  );
+});
+
+export const placeConfirmedOrder = Effect.fn("CoffeeOrders.placeConfirmedOrder")(function* (
+  request: PlaceOrderRequest,
+): Effect.fn.Return<
+  CoffeeOrder,
+  AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError,
+  MenuRepository | OrderIdGenerator | OrderRepository | PendingOrderConfirmationRepository
+> {
+  const confirmation = yield* loadPendingConfirmation();
+  yield* assertPendingSource(confirmation, "direct-order");
+  const quote = yield* resolveOrderQuote(request.items);
+  yield* assertPendingQuote({ actual: quote, pending: confirmation });
+  const order = yield* placeOrder(request);
+  const repository = yield* PendingOrderConfirmationRepository;
+  yield* repository
+    .clear(confirmation.ownerUserId)
+    .pipe(
+      Effect.mapError(
+        internalAppErrorFromPersistence("Unable to clear pending order confirmation right now"),
+      ),
+    );
+  return order;
+});
+
+export const checkoutConfirmedCart = Effect.fn("CoffeeOrders.checkoutConfirmedCart")(function* (
+  request: CheckoutCartRequest,
+): Effect.fn.Return<
+  CoffeeOrder,
+  AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError,
+  | CartRepository
+  | MenuRepository
+  | OrderIdGenerator
+  | OrderRepository
+  | PendingOrderConfirmationRepository
+> {
+  const confirmation = yield* loadPendingConfirmation();
+  yield* assertPendingSource(confirmation, "cart");
+  const cartRepository = yield* CartRepository;
+  const cart = yield* cartRepository.getByOwnerUserId(confirmation.ownerUserId).pipe(
+    Effect.mapError(internalAppErrorFromPersistence("Unable to load cart right now")),
+    Effect.flatMap(
+      Option.match({
+        onNone: () => Effect.fail(invalidOrderInput("confirm the updated order before placing it")),
+        onSome: Effect.succeed,
+      }),
+    ),
+  );
+  const items = yield* decodeOrderItemsInput(cart.items.map(toOrderItemInput)).pipe(
+    Effect.catchTag("SchemaError", () =>
+      Effect.fail(invalidOrderInput("confirm the updated order before placing it")),
+    ),
+  );
+  const quote = yield* resolveOrderQuote(items);
+  yield* assertPendingQuote({ actual: quote, pending: confirmation });
+  const order = yield* checkoutCart(request);
+  const repository = yield* PendingOrderConfirmationRepository;
+  yield* repository
+    .clear(confirmation.ownerUserId)
+    .pipe(
+      Effect.mapError(
+        internalAppErrorFromPersistence("Unable to clear pending order confirmation right now"),
+      ),
+    );
+  return order;
+});

--- a/packages/coffee/core/src/application/use-cases/index.ts
+++ b/packages/coffee/core/src/application/use-cases/index.ts
@@ -7,6 +7,7 @@ export {
   updateCartItem,
 } from "./cart.ts";
 export { markReady, cancelOrder, pickUpOrder, startBrewing } from "./changeOrderStatus.ts";
+export { checkoutConfirmedCart, placeConfirmedOrder } from "./confirmedPurchase.ts";
 export { getItemOptions } from "./getItemOptions.ts";
 export { getOrder } from "./getOrder.ts";
 export { listMenu } from "./listMenu.ts";

--- a/packages/coffee/presentation/mcp/src/action-tools.ts
+++ b/packages/coffee/presentation/mcp/src/action-tools.ts
@@ -29,7 +29,8 @@ export const CoffeeActionToolsLive = McpServer.toolkit(CoffeeActionToolkit).pipe
             app.prepareOrderConfirmation(input).pipe(Effect.map(toPendingOrderConfirmationView)),
           prepare_cart_confirmation: () =>
             app.prepareCartConfirmation().pipe(Effect.map(toPendingOrderConfirmationView)),
-          place_order: (input) => app.placeOrder(input).pipe(Effect.map(toCoffeeOrderView)),
+          place_order: (input) =>
+            app.placeConfirmedOrder(input).pipe(Effect.map(toCoffeeOrderView)),
           get_order: ({ orderId }) => app.getOrder(orderId).pipe(Effect.map(toCoffeeOrderView)),
           list_orders: (input) => app.listOrders(input).pipe(Effect.map(toCoffeeOrdersView)),
           start_brewing: ({ orderId }) =>
@@ -44,7 +45,8 @@ export const CoffeeActionToolsLive = McpServer.toolkit(CoffeeActionToolkit).pipe
           update_cart_item: (input) => app.updateCartItem(input).pipe(Effect.map(toCartView)),
           remove_cart_item: (input) => app.removeCartItem(input).pipe(Effect.map(toCartView)),
           clear_cart: () => app.clearCart().pipe(Effect.map(toCartView)),
-          checkout_cart: (input) => app.checkoutCart(input).pipe(Effect.map(toCoffeeOrderView)),
+          checkout_cart: (input) =>
+            app.checkoutConfirmedCart(input).pipe(Effect.map(toCoffeeOrderView)),
         }),
       ),
     ),


### PR DESCRIPTION
ELI5: Beanline now refuses to spend money unless the exact interpreted order or cart has already been prepared and is still unchanged.

Why this is valuable:
- Prevents surprise purchases when no confirmation exists.
- Forces the assistant to read back changed orders again before buying.
- Makes the product safer even if the model tries to call a purchase tool too early.

What changed:
- Added confirmed purchase use cases for direct orders and cart checkout.
- Routed `place_order` and `checkout_cart` actions/MCP handlers through the confirmed purchase path.
- Compared resolved order totals/items against pending confirmation state and cleared that state after successful purchase.
- Updated MCP, agent-auth, and cart planning tests to prepare confirmation before purchase.

Verification:
- `bun run typecheck`
- `bun run fmt:check`
- `bun run lint:custom`
- `bun run fallow:audit`
- `bun run --cwd apps/backend test -- test/application-use-cases/cart.test.ts src/cloudflare/mcp-miniflare-worker.test.ts test/integration/llm-mcp-client.test.ts`
- `bun run --cwd packages/coffee/assistant test`
- `bun run --cwd packages/coffee/auth test`
- `bun run --cwd packages/coffee/presentation/mcp test` with no test files found / passWithNoTests
