### PR TITLE
test(prime): add confirmation-first eval split

### DIFF
--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -32,10 +32,11 @@ Prime CLI rejects it as a `checkpoint_id` for new training runs.
 ## Receipt Run
 
 Use the small budget-capped receipt-drill warmup only after fresh baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.17`. Version `0.1.17` should be
-used for the next baseline because it contains the PR 47 hardening, prompt-only
-receipt/direct-tool-path tightening, order-first tool presentation, and the
-confirmation-before-purchase policy plus aligned product-readiness scoring.
+`kevinmichaelchen/effect-coffee-ordering@0.1.18` once published. Version
+`0.1.18` should be used for the next baseline because it contains the PR 47
+hardening, prompt-only receipt/direct-tool-path tightening, order-first tool
+presentation, confirmation-before-purchase policy, aligned product-readiness
+scoring, and the dedicated `confirmation_first` split.
 
 ```sh
 cd experiments/prime-intellect/effect-coffee-ordering
@@ -55,12 +56,13 @@ for:
 - pre-purchase confirmation before real-money order submission,
 - concise refusal behavior.
 
-Environment `kevinmichaelchen/effect-coffee-ordering@0.1.17` is published and
-should be selected for new hosted baselines, evals, or training. It changes the
-intended product behavior: Beanline should read back the interpreted order and
-ask for confirmation before calling `place_order` or `checkout_cart`.
-The product-readiness split now rewards this confirmation path instead of
-one-shot purchase on initial order requests.
+Environment source version `0.1.18` adds a dedicated `confirmation_first` split
+and should be published before the next hosted baselines, evals, or training.
+It changes the intended product behavior: Beanline should prepare a pending
+confirmation, read back the interpreted order, and ask for confirmation before
+calling `place_order` or `checkout_cart`. The product-readiness and
+confirmation-first splits reward this path instead of one-shot purchase on
+initial order requests.
 Product-readiness is still blocked by Prime inference 503 errors.
 
 Do not rerun `effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml`
@@ -101,14 +103,14 @@ The failure is still final receipt formatting and tool overuse. Rollouts showed
 correct order fields but wrong final currency/amount style such as `₹520`
 instead of `$5.20`, plus repeated menu/option probes.
 
-Next best action is not another unchanged RL run. Retry product-readiness on
-`0.1.17` once Prime inference is stable, then use SFT on the final-response and
-tool-trajectory corpora so 0.8B learns quote/readback/confirmation before
-purchase.
+Next best action is not another unchanged RL run. Publish and retry
+product-readiness plus `confirmation_first` on `0.1.18` once Prime inference is
+stable, then use SFT on the final-response and tool-trajectory corpora so 0.8B
+learns quote/readback/confirmation before purchase.
 
 Before any new hosted training spend, run fresh hosted baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.17`; the warmup configs now pin
-that version.
+`kevinmichaelchen/effect-coffee-ordering@0.1.18` once published; the warmup
+configs now pin that version and include the `confirmation_first` eval.
 
 Inspect the stopped run:
 

--- a/experiments/prime-intellect/effect-coffee-ordering/README.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/README.md
@@ -17,7 +17,7 @@ wheels, and hosted eval outputs remain under `.context/` and are not checked in.
 - `configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml` -
   deterministic warmup fallback if hosted SFT is unavailable.
 - `configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml` -
-  broader cashier-behavior warmup after publishing environment `0.1.7`.
+  broader cashier-behavior warmup after publishing the current environment.
 
 ## Current Champion
 
@@ -68,10 +68,14 @@ define a better coffee-shop assistant beyond receipts:
 - pickup timing, customer name, and order notes,
 - concise refusal behavior.
 
-Environment version `0.1.7` is published. The first product-readiness warmup run
-(`e2s3bs35k9qwzlfbrfw0ol51`) was stopped after the first interval eval because
-it failed the hard-eval reward and verbosity gates. Do not rerun that config
-unchanged.
+The source also includes a `confirmation_first` split for the real-money
+purchase boundary. It rewards prepare/readback/ask-first behavior and penalizes
+initial one-shot purchases, ambiguous "yes" submissions, cancel requests, and
+stale confirmations.
+
+The first product-readiness warmup run (`e2s3bs35k9qwzlfbrfw0ol51`) was stopped
+after the first interval eval because it failed the hard-eval reward and
+verbosity gates. Do not rerun that config unchanged.
 
 ## Prime Hosted RL
 

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.17 before launching this.
+# Publish the checked-in environment as version 0.1.18 before launching this.
 # This broadens training from receipt formatting into cashier product behavior.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.17"
+version = "0.1.18"
 args = { split = "product_readiness" }
 
 [val]
@@ -40,7 +40,7 @@ eval_base_model = false
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-hard-eval"
-version = "0.1.17"
+version = "0.1.18"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
@@ -48,9 +48,17 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-product-readiness"
-version = "0.1.17"
+version = "0.1.18"
 args = { split = "product_readiness" }
 num_examples = 16
+rollouts_per_example = 2
+
+[[eval.env]]
+id = "kevinmichaelchen/effect-coffee-ordering"
+name = "effect-coffee-confirmation-first"
+version = "0.1.18"
+args = { split = "confirmation_first" }
+num_examples = 6
 rollouts_per_example = 2
 
 [adapters]

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.17 before launching this.
+# Publish the checked-in environment as version 0.1.18 before launching this.
 # This is the deterministic fallback if hosted SFT is still unavailable.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.17"
+version = "0.1.18"
 args = { split = "receipt_drill" }
 
 [val]
@@ -39,9 +39,16 @@ eval_base_model = false
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.17"
+version = "0.1.18"
 args = { split = "hard_eval" }
 num_examples = 8
+rollouts_per_example = 2
+
+[[eval.env]]
+id = "kevinmichaelchen/effect-coffee-ordering"
+version = "0.1.18"
+args = { split = "confirmation_first" }
+num_examples = 6
 rollouts_per_example = 2
 
 [adapters]

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py
@@ -70,12 +70,13 @@ SYSTEM_PROMPT = """You are Beanline, the Effect Coffee Shop ordering assistant.
 Use the coffee tools instead of inventing menu, price, cart, or order state.
 Use the smallest useful tool path.
 Because orders spend real money, read back the interpreted order and ask for confirmation before purchase.
-On an initial order request, do not call place_order or checkout_cart yet; use quote_order, cart tools, or option tools only as needed to verify the proposed order and total.
-Call place_order or checkout_cart only after the user explicitly confirms the final order, such as "yes, place it" or "submit that order".
+On an initial order request, do not call place_order or checkout_cart yet; use prepare_order_confirmation for a direct proposed order, or cart tools followed by prepare_cart_confirmation for cart workflows.
+Call place_order or checkout_cart only after the user explicitly confirms the final order, such as "yes, place it" or "submit that order", and pass the latest confirmation_id returned by the matching prepare tool.
+Purchase tools require matching pending confirmation state; if the order changed, prepare confirmation again and ask the user to confirm again.
 Use list_menu for general menu, substitution, unavailable ingredient, or recommendation questions.
 Use get_item_options for a specific drink's defaults and valid options when the user asks or a drink option is unclear.
-Use validate_order or quote_order only when options, price, or defaults are uncertain.
-Use cart tools for multi-item cart workflows, then checkout_cart.
+Use validate_order or quote_order only when options, price, or defaults are uncertain and you are not ready to create pending confirmation state.
+Use cart tools for multi-item cart workflows, then prepare_cart_confirmation, then checkout_cart after explicit confirmation.
 Safe defaults are allowed: medium size when size is missing, whole milk for milk-capable drinks, none for no-milk drinks, the drink's default temperature, one espresso shot, zero tea shots, and quantity one.
 Ask one short clarifying question when the drink, customer name, or another order-critical field is missing.
 Pre-purchase confirmation template: "I have <drink summary> for <name>, total $x.xx. Should I place it?"

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
@@ -906,6 +906,125 @@ PRODUCT_READINESS_TASKS = [
     },
 ]
 
+CONFIRMATION_FIRST_TASKS = [
+    {
+        "question": "Order a medium hot whole milk latte for Rowan.",
+        "info": {
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["prepare_order_confirmation"],
+            "expected_tool_sequence": ["prepare_order_confirmation"],
+            "expected_tool_counts": {"prepare_order_confirmation": 1, "place_order": 0},
+            "required_terms": ["Latte", "Rowan", "$5.18", "Should I place"],
+            "expected_order": {"customer_name": "Rowan"},
+            "expected_items": [
+                {
+                    "drink_id": "latte",
+                    "size": "medium",
+                    "milk": "whole",
+                    "temperature": "hot",
+                    "shots": 1,
+                    "quantity": 1,
+                }
+            ],
+        },
+    },
+    {
+        "question": "Can you start a cart with a medium oat latte for Ava and a small espresso for Ben?",
+        "info": {
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["add_cart_item", "prepare_cart_confirmation"],
+            "expected_tool_sequence": ["add_cart_item", "add_cart_item", "prepare_cart_confirmation"],
+            "expected_tool_counts": {
+                "add_cart_item": 2,
+                "prepare_cart_confirmation": 1,
+                "checkout_cart": 0,
+            },
+            "required_terms": ["Latte", "Espresso", "Ava", "$8.18", "Should I place"],
+            "expected_order": {"customer_name": "Ava"},
+            "expected_items": [
+                {
+                    "drink_id": "latte",
+                    "size": "medium",
+                    "milk": "oat",
+                    "temperature": "hot",
+                    "shots": 1,
+                    "quantity": 1,
+                },
+                {
+                    "drink_id": "espresso",
+                    "size": "small",
+                    "milk": "none",
+                    "temperature": "hot",
+                    "shots": 1,
+                    "quantity": 1,
+                },
+            ],
+        },
+    },
+    {
+        "question": (
+            "I said a medium latte for Nia, but before you place anything make it a "
+            "large iced oat latte with two shots."
+        ),
+        "info": {
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["prepare_order_confirmation"],
+            "expected_tool_sequence": ["prepare_order_confirmation"],
+            "expected_tool_counts": {"prepare_order_confirmation": 1, "place_order": 0},
+            "required_terms": ["Latte", "Nia", "$6.60", "Should I place"],
+            "expected_order": {"customer_name": "Nia"},
+            "expected_items": [
+                {
+                    "drink_id": "latte",
+                    "size": "large",
+                    "milk": "oat",
+                    "temperature": "iced",
+                    "shots": 2,
+                    "quantity": 1,
+                }
+            ],
+        },
+    },
+    {
+        "question": "Yes, place it.",
+        "info": {
+            "expected_action": "refuse",
+            "required_terms": ["which order", "confirm", "before"],
+            "expected_tool_counts": {"place_order": 0, "checkout_cart": 0},
+        },
+    },
+    {
+        "question": "Order a small hot cappuccino for Luca. Actually, cancel that request.",
+        "info": {
+            "expected_action": "refuse",
+            "required_terms": ["cancel", "not place", "order"],
+            "expected_tool_counts": {"prepare_order_confirmation": 0, "place_order": 0},
+        },
+    },
+    {
+        "question": "I confirmed the old latte, but now make Jamie a medium iced americano with light ice instead.",
+        "info": {
+            "expected_action": "confirm_order",
+            "expected_tool_names": ["prepare_order_confirmation"],
+            "expected_tool_sequence": ["prepare_order_confirmation"],
+            "expected_tool_counts": {"prepare_order_confirmation": 1, "place_order": 0},
+            "required_terms": ["Americano", "Jamie", "$4.02", "Should I place"],
+            "expected_order": {"customer_name": "Jamie"},
+            "expected_items": [
+                {
+                    "drink_id": "americano",
+                    "size": "medium",
+                    "milk": "none",
+                    "temperature": "iced",
+                    "shots": 1,
+                    "quantity": 1,
+                    "notes": "light ice",
+                }
+            ],
+        },
+    },
+]
+
 
 async def list_menu() -> str:
     """List the current coffee menu.
@@ -998,6 +1117,44 @@ async def quote_order(
     return json.dumps(quote_payload(items, drink_id, size, milk, temperature, shots, notes, quantity), sort_keys=True)
 
 
+async def prepare_order_confirmation(
+    items_json: str = "",
+    drink_id: str = "",
+    size: str = "",
+    milk: str = "",
+    temperature: str = "",
+    shots: int | None = None,
+    notes: str = "",
+    quantity: int | None = None,
+) -> str:
+    """Validate, price, and store a proposed order awaiting confirmation."""
+    items = parse_items_json(items_json)
+    if isinstance(items, dict):
+        return json.dumps(items, sort_keys=True)
+    quote = quote_payload(items, drink_id, size, milk, temperature, shots, notes, quantity)
+    if quote.get("ok") is not True:
+        return json.dumps(quote, sort_keys=True)
+    confirmation = pending_confirmation_payload(
+        "direct-order",
+        quote["items"],
+        quote["total_price_cents"],
+    )
+    save_pending_confirmation(confirmation)
+    return json.dumps({"ok": True, **confirmation}, sort_keys=True)
+
+
+async def prepare_cart_confirmation() -> str:
+    """Validate, price, and store the current simulated cart awaiting confirmation."""
+    cart = cart_payload()
+    cart_items = cart["items"]
+    if not cart_items:
+        return json.dumps({"ok": False, "error": "cart must include at least one item"}, sort_keys=True)
+    items = [entry["item"] for entry in cart_items]
+    confirmation = pending_confirmation_payload("cart", items, cart["total_price_cents"])
+    save_pending_confirmation(confirmation)
+    return json.dumps({"ok": True, **confirmation}, sort_keys=True)
+
+
 async def place_order(
     items_json: str = "",
     drink_id: str = "",
@@ -1008,6 +1165,7 @@ async def place_order(
     customer_name: str = "",
     notes: str = "",
     quantity: int | None = None,
+    confirmation_id: str = "",
 ) -> str:
     """Create a simulated coffee order if the requested items are valid.
 
@@ -1025,7 +1183,15 @@ async def place_order(
     quote = quote_payload(items, drink_id, size, milk, temperature, shots, notes, quantity)
     if quote.get("ok") is not True:
         return json.dumps(quote, sort_keys=True)
+    if confirmation_id and not pending_confirmation_matches(
+        confirmation_id,
+        "direct-order",
+        quote["items"],
+        quote["total_price_cents"],
+    ):
+        return json.dumps({"ok": False, "error": "confirm the updated order before placing it"}, sort_keys=True)
     order = order_payload(quote["items"], customer_name)
+    clear_pending_confirmation()
     return json.dumps({"ok": True, "order": order}, sort_keys=True)
 
 
@@ -1100,17 +1266,28 @@ async def clear_cart() -> str:
     return json.dumps({"ok": True, "cart": cart_payload()}, sort_keys=True)
 
 
-async def checkout_cart(customer_name: str = "") -> str:
+async def checkout_cart(customer_name: str = "", confirmation_id: str = "") -> str:
     """Place the current simulated cart as one multi-item order."""
     cart = rollout_cart()
     if not cart:
         return json.dumps({"ok": False, "error": "cart must include at least one item"}, sort_keys=True)
-    order = order_payload([entry["item"] for entry in cart], customer_name)
+    items = [entry["item"] for entry in cart]
+    total = sum(item["line_total_cents"] for item in items)
+    if confirmation_id and not pending_confirmation_matches(
+        confirmation_id,
+        "cart",
+        items,
+        total,
+    ):
+        return json.dumps({"ok": False, "error": "confirm the updated order before placing it"}, sort_keys=True)
+    order = order_payload(items, customer_name)
     reset_cart()
+    clear_pending_confirmation()
     return json.dumps({"ok": True, "order": order}, sort_keys=True)
 
 
 _CARTS: dict[int, dict[str, Any]] = {}
+_PENDING_CONFIRMATIONS: dict[int, dict[str, Any]] = {}
 
 
 def cart_key() -> int:
@@ -1144,6 +1321,57 @@ def cart_payload() -> dict[str, Any]:
     cart = rollout_cart()
     total = sum(entry["item"]["line_total_cents"] for entry in cart)
     return {"items": cart, "total_price_cents": total, "totalPriceCents": total}
+
+
+def pending_confirmation_payload(
+    source: str,
+    items: list[dict[str, Any]],
+    total_price_cents: int,
+) -> dict[str, Any]:
+    confirmation_id = f"confirmation-{cart_key():x}-{rollout_cart_state()['next_id']:04d}"
+    return {
+        "confirmation": {
+            "confirmation_id": confirmation_id,
+            "confirmationId": confirmation_id,
+            "source": source,
+            "status": "pending_confirmation",
+            "items": items,
+            "total_price_cents": total_price_cents,
+            "totalPriceCents": total_price_cents,
+        },
+        "confirmation_id": confirmation_id,
+        "confirmationId": confirmation_id,
+        "source": source,
+        "status": "pending_confirmation",
+        "items": items,
+        "total_price_cents": total_price_cents,
+        "totalPriceCents": total_price_cents,
+    }
+
+
+def save_pending_confirmation(confirmation: dict[str, Any]) -> None:
+    _PENDING_CONFIRMATIONS[cart_key()] = confirmation
+
+
+def clear_pending_confirmation() -> None:
+    _PENDING_CONFIRMATIONS.pop(cart_key(), None)
+
+
+def pending_confirmation_matches(
+    confirmation_id: str,
+    source: str,
+    items: list[dict[str, Any]],
+    total_price_cents: int,
+) -> bool:
+    pending = _PENDING_CONFIRMATIONS.get(cart_key())
+    if pending is None:
+        return False
+    return (
+        pending.get("confirmation_id") == confirmation_id
+        and pending.get("source") == source
+        and pending.get("items") == items
+        and pending.get("total_price_cents") == total_price_cents
+    )
 
 
 def parse_items_json(items_json: str) -> list[dict[str, Any]] | dict[str, Any] | None:
@@ -1699,6 +1927,7 @@ def load_environment(split: str = "train", num_examples: int = -1, **kwargs) -> 
     hard_eval_dataset = to_dataset(HARD_EVAL_TASKS)
     receipt_drill_dataset = to_dataset(RECEIPT_DRILL_TASKS)
     product_readiness_dataset = to_dataset(PRODUCT_READINESS_TASKS)
+    confirmation_first_dataset = to_dataset(CONFIRMATION_FIRST_TASKS)
 
     datasets = {
         "train": train_dataset,
@@ -1706,6 +1935,7 @@ def load_environment(split: str = "train", num_examples: int = -1, **kwargs) -> 
         "hard_eval": hard_eval_dataset,
         "receipt_drill": receipt_drill_dataset,
         "product_readiness": product_readiness_dataset,
+        "confirmation_first": confirmation_first_dataset,
     }
     selected_dataset = datasets.get(split, train_dataset)
     if num_examples > 0:
@@ -1718,6 +1948,8 @@ def load_environment(split: str = "train", num_examples: int = -1, **kwargs) -> 
     )
 
     ordering_tools = [
+        prepare_order_confirmation,
+        prepare_cart_confirmation,
         place_order,
         add_cart_item,
         checkout_cart,

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
@@ -2,7 +2,7 @@
 name = "effect-coffee-ordering"
 description = "Tool-use environment for training coffee-shop ordering assistants."
 tags = ["tool-use", "coffee", "ordering", "train", "eval"]
-version = "0.1.17"
+version = "0.1.18"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@3b77145e14a9bcdaf180a49e7df97dbf2d7bb150",

--- a/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
@@ -59,6 +59,32 @@ class EnvironmentLogicTests(unittest.TestCase):
         self.assertEqual(len(environment.dataset), len(env.PRODUCT_READINESS_TASKS))
         self.assertEqual(len(environment.eval_dataset), len(env.PRODUCT_READINESS_TASKS))
 
+    def test_confirmation_first_uses_selected_dataset_for_eval(self):
+        environment = env.load_environment(split="confirmation_first")
+
+        self.assertEqual(len(environment.dataset), len(env.CONFIRMATION_FIRST_TASKS))
+        self.assertEqual(len(environment.eval_dataset), len(env.CONFIRMATION_FIRST_TASKS))
+
+    def test_prepare_order_confirmation_returns_pending_ticket(self):
+        async def run():
+            return await env.prepare_order_confirmation(
+                items_json=json.dumps(
+                    {
+                        "drink_id": "latte",
+                        "milk": "oat",
+                        "size": "medium",
+                    }
+                )
+            )
+
+        payload = json.loads(asyncio.run(run()))
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["status"], "pending_confirmation")
+        self.assertEqual(payload["source"], "direct-order")
+        self.assertEqual(payload["items"][0]["drink_id"], "latte")
+        self.assertIn("confirmation_id", payload)
+
     def test_place_order_accepts_single_item_json_payload(self):
         async def run():
             return await env.place_order(
@@ -102,7 +128,10 @@ class EnvironmentLogicTests(unittest.TestCase):
             ],
             "total_price_cents": 818,
         }
-        final_text = "I have a medium hot oat milk Latte and a small hot Espresso for Ava, total $8.18. Should I place it?"
+        final_text = (
+            "I have a medium hot oat milk Latte and a small hot Espresso for Ava, "
+            "total $8.18. Should I place it?"
+        )
         info = env.PRODUCT_READINESS_TASKS[0]["info"]
         good_completion = [
             {"role": "tool", "name": "add_cart_item", "content": json.dumps({"ok": True, "cart": first_cart})},
@@ -120,6 +149,39 @@ class EnvironmentLogicTests(unittest.TestCase):
 
         self.assertEqual(good_score, 1.0)
         self.assertLess(premature_checkout_score, good_score)
+
+    def test_confirmation_first_rewards_prepare_before_purchase(self):
+        item = env.quote_payload(None, "latte", "medium", "whole", "hot", 1, "", 1)["items"][0]
+        order = env.order_payload([item], "Rowan")
+        confirmation = {
+            "ok": True,
+            "confirmation_id": "confirmation-test-0001",
+            "source": "direct-order",
+            "status": "pending_confirmation",
+            "items": [item],
+            "total_price_cents": 518,
+        }
+        info = env.CONFIRMATION_FIRST_TASKS[0]["info"]
+        good_completion = [
+            {"role": "tool", "name": "prepare_order_confirmation", "content": json.dumps(confirmation)},
+            {
+                "role": "assistant",
+                "content": (
+                    "I have a medium hot whole milk Latte for Rowan, total $5.18. "
+                    "Should I place it?"
+                ),
+            },
+        ]
+        premature_order_completion = [
+            {"role": "tool", "name": "place_order", "content": json.dumps({"ok": True, "order": order})},
+            {"role": "assistant", "content": "Latte. Order order-simulated-0001. Total $5.18."},
+        ]
+
+        good_score = asyncio.run(env.product_efficiency(good_completion, info))
+        premature_order_score = asyncio.run(env.product_efficiency(premature_order_completion, info))
+
+        self.assertEqual(good_score, 1.0)
+        self.assertLess(premature_order_score, good_score)
 
     def test_price_format_rejects_wrong_currency_and_cent_totals(self):
         item = env.quote_payload(None, "latte", "medium", "whole", "hot", 1, "", 1)["items"][0]
@@ -142,6 +204,8 @@ class EnvironmentLogicTests(unittest.TestCase):
 
         self.assertIn("read back the interpreted order and ask for confirmation before purchase", prompt)
         self.assertIn("do not call place_order or checkout_cart yet", prompt)
+        self.assertIn("prepare_order_confirmation", prompt)
+        self.assertIn("confirmation_id", prompt)
         self.assertIn("Call place_order or checkout_cart only after the user explicitly confirms", prompt)
         self.assertIn("Should I place it?", prompt)
         self.assertIn("520 cents becomes $5.20", prompt)
@@ -151,7 +215,8 @@ class EnvironmentLogicTests(unittest.TestCase):
         environment = env.load_environment(split="hard_eval")
         tool_names = [tool.__name__ for tool in environment.tools]
 
-        self.assertEqual(tool_names[:3], ["place_order", "add_cart_item", "checkout_cart"])
+        self.assertEqual(tool_names[:3], ["prepare_order_confirmation", "prepare_cart_confirmation", "place_order"])
+        self.assertLess(tool_names.index("prepare_order_confirmation"), tool_names.index("place_order"))
         self.assertLess(tool_names.index("place_order"), tool_names.index("list_menu"))
         self.assertLess(tool_names.index("place_order"), tool_names.index("get_item_options"))
 


### PR DESCRIPTION
ELI5: This adds a driving test for the cashier. If a shopper asks for coffee, the model is rewarded for writing down the order and asking “Should I place it?” before charging.

Why this is valuable:
- Gives us a dedicated eval for the highest-stakes behavior: confirmation before purchase.
- Penalizes immediate purchase on initial order requests.
- Covers direct orders, carts, edits, cancellations, ambiguous yes/no situations, and stale confirmations.

What changed:
- Added `prepare_order_confirmation` and `prepare_cart_confirmation` tools to the Prime environment.
- Added a `confirmation_first` split for confirmation-before-purchase scenarios.
- Updated the Prime system prompt and environment tests while keeping older splits compatible.

Verification:
- `python -m unittest experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py`
- `python -m py_compile experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py`
- `bun run check:affected`
