### PR TITLE
test(prime): require confirmation tokens for purchases

### DIFF
--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -32,11 +32,12 @@ Prime CLI rejects it as a `checkpoint_id` for new training runs.
 ## Receipt Run
 
 Use the small budget-capped receipt-drill warmup only after fresh baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.18` once published. Version
-`0.1.18` should be used for the next baseline because it contains the PR 47
+`kevinmichaelchen/effect-coffee-ordering@0.1.19` once published. Version
+`0.1.19` should be used for the next baseline because it contains the PR 47
 hardening, prompt-only receipt/direct-tool-path tightening, order-first tool
 presentation, confirmation-before-purchase policy, aligned product-readiness
-scoring, and the dedicated `confirmation_first` split.
+scoring, the dedicated `confirmation_first` split, and purchase-tool rejection
+when the model omits the required confirmation token.
 
 ```sh
 cd experiments/prime-intellect/effect-coffee-ordering
@@ -56,13 +57,14 @@ for:
 - pre-purchase confirmation before real-money order submission,
 - concise refusal behavior.
 
-Environment source version `0.1.18` adds a dedicated `confirmation_first` split
-and should be published before the next hosted baselines, evals, or training.
-It changes the intended product behavior: Beanline should prepare a pending
-confirmation, read back the interpreted order, and ask for confirmation before
-calling `place_order` or `checkout_cart`. The product-readiness and
-confirmation-first splits reward this path instead of one-shot purchase on
-initial order requests.
+Environment source version `0.1.19` adds a dedicated `confirmation_first` split,
+and `place_order`/`checkout_cart` now reject calls unless the confirmation token
+matches the pending confirmation. Publish it before the next hosted baselines,
+evals, or training. It changes the intended product behavior: Beanline should
+prepare a pending confirmation, read back the interpreted order, and ask for
+confirmation before calling `place_order` or `checkout_cart`. The
+product-readiness and confirmation-first splits reward this path instead of
+one-shot purchase on initial order requests.
 Product-readiness is still blocked by Prime inference 503 errors.
 
 Do not rerun `effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml`
@@ -104,12 +106,12 @@ correct order fields but wrong final currency/amount style such as `₹520`
 instead of `$5.20`, plus repeated menu/option probes.
 
 Next best action is not another unchanged RL run. Publish and retry
-product-readiness plus `confirmation_first` on `0.1.18` once Prime inference is
+product-readiness plus `confirmation_first` on `0.1.19` once Prime inference is
 stable, then use SFT on the final-response and tool-trajectory corpora so 0.8B
 learns quote/readback/confirmation before purchase.
 
 Before any new hosted training spend, run fresh hosted baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.18` once published; the warmup
+`kevinmichaelchen/effect-coffee-ordering@0.1.19` once published; the warmup
 configs now pin that version and include the `confirmation_first` eval.
 
 Inspect the stopped run:

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.18 before launching this.
+# Publish the checked-in environment as version 0.1.19 before launching this.
 # This broadens training from receipt formatting into cashier product behavior.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "product_readiness" }
 
 [val]
@@ -40,7 +40,7 @@ eval_base_model = false
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-hard-eval"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
@@ -48,7 +48,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-product-readiness"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "product_readiness" }
 num_examples = 16
 rollouts_per_example = 2
@@ -56,7 +56,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-confirmation-first"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "confirmation_first" }
 num_examples = 6
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.18 before launching this.
+# Publish the checked-in environment as version 0.1.19 before launching this.
 # This is the deterministic fallback if hosted SFT is still unavailable.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "receipt_drill" }
 
 [val]
@@ -39,14 +39,14 @@ eval_base_model = false
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.18"
+version = "0.1.19"
 args = { split = "confirmation_first" }
 num_examples = 6
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
@@ -1183,7 +1183,7 @@ async def place_order(
     quote = quote_payload(items, drink_id, size, milk, temperature, shots, notes, quantity)
     if quote.get("ok") is not True:
         return json.dumps(quote, sort_keys=True)
-    if confirmation_id and not pending_confirmation_matches(
+    if not pending_confirmation_matches(
         confirmation_id,
         "direct-order",
         quote["items"],
@@ -1273,7 +1273,7 @@ async def checkout_cart(customer_name: str = "", confirmation_id: str = "") -> s
         return json.dumps({"ok": False, "error": "cart must include at least one item"}, sort_keys=True)
     items = [entry["item"] for entry in cart]
     total = sum(item["line_total_cents"] for item in items)
-    if confirmation_id and not pending_confirmation_matches(
+    if not pending_confirmation_matches(
         confirmation_id,
         "cart",
         items,

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
@@ -2,7 +2,7 @@
 name = "effect-coffee-ordering"
 description = "Tool-use environment for training coffee-shop ordering assistants."
 tags = ["tool-use", "coffee", "ordering", "train", "eval"]
-version = "0.1.18"
+version = "0.1.19"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@3b77145e14a9bcdaf180a49e7df97dbf2d7bb150",

--- a/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
@@ -85,7 +85,7 @@ class EnvironmentLogicTests(unittest.TestCase):
         self.assertEqual(payload["items"][0]["drink_id"], "latte")
         self.assertIn("confirmation_id", payload)
 
-    def test_place_order_accepts_single_item_json_payload(self):
+    def test_place_order_requires_pending_confirmation(self):
         async def run():
             return await env.place_order(
                 items_json=json.dumps(
@@ -100,10 +100,67 @@ class EnvironmentLogicTests(unittest.TestCase):
 
         payload = json.loads(asyncio.run(run()))
 
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "confirm the updated order before placing it")
+
+    def test_place_order_accepts_matching_confirmation(self):
+        async def run():
+            confirmation = json.loads(
+                await env.prepare_order_confirmation(
+                    items_json=json.dumps(
+                        {
+                            "drink_id": "latte",
+                            "milk": "oat",
+                            "temperature": "iced",
+                        }
+                    )
+                )
+            )
+            return await env.place_order(
+                items_json=json.dumps(
+                    {
+                        "drink_id": "latte",
+                        "milk": "oat",
+                        "temperature": "iced",
+                    }
+                ),
+                customer_name="Ivy",
+                confirmation_id=confirmation["confirmation_id"],
+            )
+
+        payload = json.loads(asyncio.run(run()))
+
         self.assertTrue(payload["ok"])
         self.assertEqual(payload["order"]["customer_name"], "Ivy")
         self.assertEqual(payload["order"]["items"][0]["size"], "medium")
         self.assertEqual(payload["order"]["items"][0]["shots"], 1)
+
+    def test_checkout_cart_requires_pending_confirmation(self):
+        async def run():
+            await env.clear_cart()
+            await env.add_cart_item("latte", milk="oat")
+            return await env.checkout_cart(customer_name="Ivy")
+
+        payload = json.loads(asyncio.run(run()))
+
+        self.assertFalse(payload["ok"])
+        self.assertEqual(payload["error"], "confirm the updated order before placing it")
+
+    def test_checkout_cart_accepts_matching_confirmation(self):
+        async def run():
+            await env.clear_cart()
+            await env.add_cart_item("latte", milk="oat")
+            confirmation = json.loads(await env.prepare_cart_confirmation())
+            return await env.checkout_cart(
+                customer_name="Ivy",
+                confirmation_id=confirmation["confirmation_id"],
+            )
+
+        payload = json.loads(asyncio.run(run()))
+
+        self.assertTrue(payload["ok"])
+        self.assertEqual(payload["order"]["customer_name"], "Ivy")
+        self.assertEqual(payload["order"]["items"][0]["drink_id"], "latte")
 
     def test_cart_item_ids_do_not_reuse_removed_ids(self):
         async def run():


### PR DESCRIPTION
ELI5: The training register should behave like a real register. Before this, the simulated purchase tools rejected a wrong confirmation ticket but still let the model buy when it skipped the ticket entirely.

Why this is valuable:
- Makes the training environment enforce the same safety rule as the product.
- Stops the model from learning a shortcut that would fail in the real app.
- Gives us tests for both direct-order and cart checkout confirmation-token enforcement.

What changed:
- Requires matching `confirmation_id` for `place_order` and `checkout_cart` in the Prime environment.
- Adds direct-order and cart tests for missing-token rejection and matching-token success.
- Bumps the unpublished environment/config pins to `0.1.19` and updates `NEXT_STEPS`.

Verification:
- `python -m unittest experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py`
- `python -m py_compile experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py`
- `bun run check:affected`
