### PR TITLE
test(prime): teach pending confirmation lookup

### DIFF
--- a/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
+++ b/experiments/prime-intellect/effect-coffee-ordering/NEXT_STEPS.md
@@ -32,12 +32,14 @@ Prime CLI rejects it as a `checkpoint_id` for new training runs.
 ## Receipt Run
 
 Use the small budget-capped receipt-drill warmup only after fresh baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.19` once published. Version
-`0.1.19` should be used for the next baseline because it contains the PR 47
+`kevinmichaelchen/effect-coffee-ordering@0.1.20` once published. Version
+`0.1.20` should be used for the next baseline because it contains the PR 47
 hardening, prompt-only receipt/direct-tool-path tightening, order-first tool
 presentation, confirmation-before-purchase policy, aligned product-readiness
 scoring, the dedicated `confirmation_first` split, and purchase-tool rejection
-when the model omits the required confirmation token.
+when the model omits the required confirmation token. It also exposes
+`get_pending_confirmation` so later-turn "yes" responses can fetch current
+pending state instead of guessing.
 
 ```sh
 cd experiments/prime-intellect/effect-coffee-ordering
@@ -57,14 +59,15 @@ for:
 - pre-purchase confirmation before real-money order submission,
 - concise refusal behavior.
 
-Environment source version `0.1.19` adds a dedicated `confirmation_first` split,
-and `place_order`/`checkout_cart` now reject calls unless the confirmation token
-matches the pending confirmation. Publish it before the next hosted baselines,
-evals, or training. It changes the intended product behavior: Beanline should
-prepare a pending confirmation, read back the interpreted order, and ask for
-confirmation before calling `place_order` or `checkout_cart`. The
-product-readiness and confirmation-first splits reward this path instead of
-one-shot purchase on initial order requests.
+Environment source version `0.1.20` adds a dedicated `confirmation_first` split
+and a `get_pending_confirmation` tool. `place_order`/`checkout_cart` now reject
+calls unless the confirmation token matches the pending confirmation. Publish it
+before the next hosted baselines, evals, or training. It changes the intended
+product behavior: Beanline should prepare a pending confirmation, read back the
+interpreted order, and ask for confirmation before calling `place_order` or
+`checkout_cart`. For later-turn confirmation, Beanline should fetch pending
+state first. The product-readiness and confirmation-first splits reward this
+path instead of one-shot purchase on initial order requests.
 Product-readiness is still blocked by Prime inference 503 errors.
 
 Do not rerun `effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml`
@@ -106,12 +109,12 @@ correct order fields but wrong final currency/amount style such as `₹520`
 instead of `$5.20`, plus repeated menu/option probes.
 
 Next best action is not another unchanged RL run. Publish and retry
-product-readiness plus `confirmation_first` on `0.1.19` once Prime inference is
+product-readiness plus `confirmation_first` on `0.1.20` once Prime inference is
 stable, then use SFT on the final-response and tool-trajectory corpora so 0.8B
 learns quote/readback/confirmation before purchase.
 
 Before any new hosted training spend, run fresh hosted baselines on
-`kevinmichaelchen/effect-coffee-ordering@0.1.19` once published; the warmup
+`kevinmichaelchen/effect-coffee-ordering@0.1.20` once published; the warmup
 configs now pin that version and include the `confirmation_first` eval.
 
 Inspect the stopped run:

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-product-readiness-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.19 before launching this.
+# Publish the checked-in environment as version 0.1.20 before launching this.
 # This broadens training from receipt formatting into cashier product behavior.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "product_readiness" }
 
 [val]
@@ -40,7 +40,7 @@ eval_base_model = false
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-hard-eval"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
@@ -48,7 +48,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-product-readiness"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "product_readiness" }
 num_examples = 16
 rollouts_per_example = 2
@@ -56,7 +56,7 @@ rollouts_per_example = 2
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
 name = "effect-coffee-confirmation-first"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "confirmation_first" }
 num_examples = 6
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/configs/rl/effect-coffee-ordering-qwen-0.8b-receipt-drill-warmup.toml
@@ -7,7 +7,7 @@ checkpoint_id = "oo8lrytspz37lfsdlloubig7"
 # Hosted Training checkpoint_id by the current Prime CLI.
 # max_steps is absolute from the source checkpoint's step 25, so 50 means 25
 # additional warmup steps.
-# Publish the checked-in environment as version 0.1.19 before launching this.
+# Publish the checked-in environment as version 0.1.20 before launching this.
 # This is the deterministic fallback if hosted SFT is still unavailable.
 max_steps = 50
 batch_size = 64
@@ -23,7 +23,7 @@ temperature = 0.4
 
 [[env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "receipt_drill" }
 
 [val]
@@ -39,14 +39,14 @@ eval_base_model = false
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "hard_eval" }
 num_examples = 8
 rollouts_per_example = 2
 
 [[eval.env]]
 id = "kevinmichaelchen/effect-coffee-ordering"
-version = "0.1.19"
+version = "0.1.20"
 args = { split = "confirmation_first" }
 num_examples = 6
 rollouts_per_example = 2

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py
@@ -72,6 +72,7 @@ Use the smallest useful tool path.
 Because orders spend real money, read back the interpreted order and ask for confirmation before purchase.
 On an initial order request, do not call place_order or checkout_cart yet; use prepare_order_confirmation for a direct proposed order, or cart tools followed by prepare_cart_confirmation for cart workflows.
 Call place_order or checkout_cart only after the user explicitly confirms the final order, such as "yes, place it" or "submit that order", and pass the latest confirmation_id returned by the matching prepare tool.
+When the user confirms in a later turn, call get_pending_confirmation first so you can use the current confirmation_id instead of guessing or exposing it to the user.
 Purchase tools require matching pending confirmation state; if the order changed, prepare confirmation again and ask the user to confirm again.
 Use list_menu for general menu, substitution, unavailable ingredient, or recommendation questions.
 Use get_item_options for a specific drink's defaults and valid options when the user asks or a drink option is unclear.

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py
@@ -989,8 +989,10 @@ CONFIRMATION_FIRST_TASKS = [
         "question": "Yes, place it.",
         "info": {
             "expected_action": "refuse",
+            "expected_tool_names": ["get_pending_confirmation"],
+            "expected_tool_sequence": ["get_pending_confirmation"],
             "required_terms": ["which order", "confirm", "before"],
-            "expected_tool_counts": {"place_order": 0, "checkout_cart": 0},
+            "expected_tool_counts": {"get_pending_confirmation": 1, "place_order": 0, "checkout_cart": 0},
         },
     },
     {
@@ -1153,6 +1155,14 @@ async def prepare_cart_confirmation() -> str:
     confirmation = pending_confirmation_payload("cart", items, cart["total_price_cents"])
     save_pending_confirmation(confirmation)
     return json.dumps({"ok": True, **confirmation}, sort_keys=True)
+
+
+async def get_pending_confirmation() -> str:
+    """Fetch the current simulated pending confirmation."""
+    pending = _PENDING_CONFIRMATIONS.get(cart_key())
+    if pending is None:
+        return json.dumps({"status": "no_pending_confirmation"}, sort_keys=True)
+    return json.dumps({"ok": True, **pending}, sort_keys=True)
 
 
 async def place_order(
@@ -1569,7 +1579,10 @@ async def tool_correctness(completion, info) -> float:
     term_score = sum(1.0 for term in required_terms if term.lower() in text.lower()) / len(
         required_terms
     )
-    return 0.5 * float(placed_order is None) + 0.5 * term_score
+    checks = [placed_order is None]
+    checks.extend(expected_tool_path_checks(info, tool_names(completion)))
+    path_score = sum(1.0 for check in checks if check) / len(checks)
+    return 0.5 * path_score + 0.5 * term_score
 
 
 async def final_response_quality(completion, info) -> float:
@@ -1718,6 +1731,7 @@ async def product_efficiency(completion, info) -> float:
         final_text != "",
         concise_text_score(final_text, max_words=36) >= 0.75,
     ]
+    checks.extend(expected_tool_path_checks(info, tool_names(completion)))
     return sum(1.0 for check in checks if check) / len(checks)
 
 
@@ -1950,6 +1964,7 @@ def load_environment(split: str = "train", num_examples: int = -1, **kwargs) -> 
     ordering_tools = [
         prepare_order_confirmation,
         prepare_cart_confirmation,
+        get_pending_confirmation,
         place_order,
         add_cart_item,
         checkout_cart,

--- a/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
+++ b/experiments/prime-intellect/effect-coffee-ordering/environment/pyproject.toml
@@ -2,7 +2,7 @@
 name = "effect-coffee-ordering"
 description = "Tool-use environment for training coffee-shop ordering assistants."
 tags = ["tool-use", "coffee", "ordering", "train", "eval"]
-version = "0.1.19"
+version = "0.1.20"
 requires-python = ">=3.10"
 dependencies = [
     "verifiers @ git+https://github.com/PrimeIntellect-ai/verifiers.git@3b77145e14a9bcdaf180a49e7df97dbf2d7bb150",

--- a/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
+++ b/experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py
@@ -85,6 +85,39 @@ class EnvironmentLogicTests(unittest.TestCase):
         self.assertEqual(payload["items"][0]["drink_id"], "latte")
         self.assertIn("confirmation_id", payload)
 
+    def test_get_pending_confirmation_returns_pending_ticket(self):
+        async def run():
+            confirmation = json.loads(
+                await env.prepare_order_confirmation(
+                    items_json=json.dumps(
+                        {
+                            "drink_id": "latte",
+                            "milk": "oat",
+                            "size": "medium",
+                        }
+                    )
+                )
+            )
+            pending = json.loads(await env.get_pending_confirmation())
+            return confirmation, pending
+
+        confirmation, pending = asyncio.run(run())
+
+        self.assertEqual(pending["ok"], True)
+        self.assertEqual(pending["status"], "pending_confirmation")
+        self.assertEqual(pending["confirmation_id"], confirmation["confirmation_id"])
+        self.assertEqual(pending["items"][0]["drink_id"], "latte")
+
+    def test_get_pending_confirmation_returns_no_pending_marker(self):
+        async def run():
+            await env.clear_cart()
+            env.clear_pending_confirmation()
+            return await env.get_pending_confirmation()
+
+        payload = json.loads(asyncio.run(run()))
+
+        self.assertEqual(payload, {"status": "no_pending_confirmation"})
+
     def test_place_order_requires_pending_confirmation(self):
         async def run():
             return await env.place_order(
@@ -240,6 +273,35 @@ class EnvironmentLogicTests(unittest.TestCase):
         self.assertEqual(good_score, 1.0)
         self.assertLess(premature_order_score, good_score)
 
+    def test_confirmation_first_rewards_lookup_before_bare_confirmation_refusal(self):
+        info = env.CONFIRMATION_FIRST_TASKS[3]["info"]
+        good_completion = [
+            {
+                "role": "tool",
+                "name": "get_pending_confirmation",
+                "content": json.dumps({"status": "no_pending_confirmation"}),
+            },
+            {
+                "role": "assistant",
+                "content": "Which order should I confirm before placing it?",
+            },
+        ]
+        no_lookup_completion = [
+            {
+                "role": "assistant",
+                "content": "Which order should I confirm before placing it?",
+            },
+        ]
+
+        good_correctness = asyncio.run(env.tool_correctness(good_completion, info))
+        no_lookup_correctness = asyncio.run(env.tool_correctness(no_lookup_completion, info))
+        good_efficiency = asyncio.run(env.product_efficiency(good_completion, info))
+        no_lookup_efficiency = asyncio.run(env.product_efficiency(no_lookup_completion, info))
+
+        self.assertEqual(good_correctness, 1.0)
+        self.assertGreater(good_efficiency, no_lookup_efficiency)
+        self.assertGreater(good_correctness, no_lookup_correctness)
+
     def test_price_format_rejects_wrong_currency_and_cent_totals(self):
         item = env.quote_payload(None, "latte", "medium", "whole", "hot", 1, "", 1)["items"][0]
         order = env.order_payload([item], "Blair")
@@ -262,6 +324,7 @@ class EnvironmentLogicTests(unittest.TestCase):
         self.assertIn("read back the interpreted order and ask for confirmation before purchase", prompt)
         self.assertIn("do not call place_order or checkout_cart yet", prompt)
         self.assertIn("prepare_order_confirmation", prompt)
+        self.assertIn("get_pending_confirmation", prompt)
         self.assertIn("confirmation_id", prompt)
         self.assertIn("Call place_order or checkout_cart only after the user explicitly confirms", prompt)
         self.assertIn("Should I place it?", prompt)
@@ -272,8 +335,17 @@ class EnvironmentLogicTests(unittest.TestCase):
         environment = env.load_environment(split="hard_eval")
         tool_names = [tool.__name__ for tool in environment.tools]
 
-        self.assertEqual(tool_names[:3], ["prepare_order_confirmation", "prepare_cart_confirmation", "place_order"])
+        self.assertEqual(
+            tool_names[:4],
+            [
+                "prepare_order_confirmation",
+                "prepare_cart_confirmation",
+                "get_pending_confirmation",
+                "place_order",
+            ],
+        )
         self.assertLess(tool_names.index("prepare_order_confirmation"), tool_names.index("place_order"))
+        self.assertLess(tool_names.index("get_pending_confirmation"), tool_names.index("place_order"))
         self.assertLess(tool_names.index("place_order"), tool_names.index("list_menu"))
         self.assertLess(tool_names.index("place_order"), tool_names.index("get_item_options"))
 


### PR DESCRIPTION
ELI5: In the real app, when a customer says “yes” later, Beanline can ask the register what order is currently waiting for confirmation. The training environment needs the same move, otherwise the model cannot practice it.

Why this is valuable:
- Aligns the training environment with the real assistant tool surface.
- Rewards checking pending state before responding to a bare “yes.”
- Prevents the model from learning to guess or invent confirmation state.

What changed:
- Added `get_pending_confirmation` to the Prime environment tools and prompt.
- Updated the `confirmation_first` “Yes, place it.” case to expect a pending-state lookup and no purchase.
- Scores expected tool paths for refusal cases so lookup behavior is rewarded.
- Bumps unpublished environment/config pins to `0.1.20` and updates `NEXT_STEPS`.

Verification:
- `python -m unittest experiments/prime-intellect/effect-coffee-ordering/tests/test_environment_logic.py`
- `python -m py_compile experiments/prime-intellect/effect-coffee-ordering/environment/effect_coffee_ordering.py experiments/prime-intellect/effect-coffee-ordering/environment/coffee_domain.py`
- `bun run check:affected`
