### PR TITLE
feat(checkout): require sessions for cart checkout

### DIFF
--- a/apps/backend/test/application-use-cases/cart.test.ts
+++ b/apps/backend/test/application-use-cases/cart.test.ts
@@ -8,6 +8,7 @@ import {
   type AppActor,
   systemActor,
 } from "@effect-coffee-shop/coffee-core/application/CurrentActor";
+import { checkoutSessionIdFromString } from "@effect-coffee-shop/coffee-core/domain/checkout-session";
 import { moneyToCents } from "@effect-coffee-shop/coffee-core/domain/money";
 import { QuoteOrderRequestSchema } from "@effect-coffee-shop/coffee-core/application/contracts";
 import {
@@ -105,12 +106,15 @@ describe("cart and order planning", () => {
       });
       assert.strictEqual(updated.items[0]?.item.shots, 2);
 
-      const order = yield* checkoutCart({});
+      const session = yield* prepareCartCheckout();
+      const order = yield* checkoutCart({ checkoutSessionId: session.id });
       const afterCheckout = yield* getCart();
+      const afterCheckoutSession = yield* getCurrentCheckoutSession();
 
       assert.strictEqual(order.items.length, 1);
       assert.strictEqual(order.items[0]?.quantity, 2);
       assert.strictEqual(afterCheckout.items.length, 0);
+      assert.deepStrictEqual(afterCheckoutSession, Option.none());
     }).pipe(provideSystemActor, Effect.provide(InMemoryCoffeeAppLive)),
   );
 
@@ -142,6 +146,18 @@ describe("cart and order planning", () => {
     }).pipe(provideSystemActor, Effect.provide(InMemoryCoffeeAppLive)),
   );
 
+  it.effect("requires the checkout session id when checking out the cart", () =>
+    Effect.gen(function* () {
+      yield* addCartItem({ drinkId: "latte", size: "medium" });
+
+      const exit = yield* checkoutCart({
+        checkoutSessionId: checkoutSessionIdFromString("checkout-session-9999"),
+      }).pipe(Effect.exit);
+
+      assert.isTrue(exit._tag === "Failure");
+    }).pipe(provideSystemActor, Effect.provide(InMemoryCoffeeAppLive)),
+  );
+
   it.effect("removes and clears cart items", () =>
     Effect.gen(function* () {
       const added = yield* addCartItem({ drinkId: "tea", size: "small" });
@@ -166,7 +182,10 @@ describe("cart and order planning", () => {
       const blakeCart = yield* addCartItem({ drinkId: "tea", size: "small" }).pipe(
         provideActor(blakeActor),
       );
-      const averyOrder = yield* checkoutCart({}).pipe(provideActor(averyActor));
+      const averySession = yield* prepareCartCheckout().pipe(provideActor(averyActor));
+      const averyOrder = yield* checkoutCart({ checkoutSessionId: averySession.id }).pipe(
+        provideActor(averyActor),
+      );
       const averyAfterCheckout = yield* getCart().pipe(provideActor(averyActor));
       const blakeAfterAveryCheckout = yield* getCart().pipe(provideActor(blakeActor));
 

--- a/packages/coffee/assistant/src/handler.ts
+++ b/packages/coffee/assistant/src/handler.ts
@@ -49,7 +49,7 @@ const coffeeAssistantSystemPrompt = [
   "Because orders spend real money, read back the interpreted order and ask for confirmation before purchase.",
   "On an initial order request, do not call place_order or checkout_cart yet; use cart tools followed by prepare_cart_checkout for cart workflows, or quote_order only when you are not ready to create a checkout session.",
   'Call place_order or checkout_cart only after the user explicitly confirms the final order, such as "yes, place it" or "submit that order".',
-  "When the user confirms in a later turn, call get_checkout_session first so you can use the current checkout session instead of guessing from chat text.",
+  "When the user confirms in a later turn, call get_checkout_session first and pass that checkoutSessionId to checkout_cart instead of guessing from chat text.",
   "Use list_menu for general menu, substitution, unavailable ingredient, or recommendation questions.",
   "Use get_item_options for a specific drink's defaults and valid choices when the user asks or a drink option is unclear.",
   "Use validate_order or quote_order only when options, price, or defaults are uncertain.",

--- a/packages/coffee/core/src/application/CoffeeOrderApp.ts
+++ b/packages/coffee/core/src/application/CoffeeOrderApp.ts
@@ -241,6 +241,7 @@ export class CoffeeOrderApp extends Context.Service<
         checkoutCart: (input) =>
           checkoutCart(input).pipe(
             Effect.provideService(CartRepository, cartRepository),
+            Effect.provideService(CheckoutSessionRepository, checkoutSessionRepository),
             Effect.provideService(MenuRepository, menuRepository),
             Effect.provideService(OrderIdGenerator, orderIdGenerator),
             Effect.provideService(OrderRepository, orderRepository),

--- a/packages/coffee/core/src/application/contracts.ts
+++ b/packages/coffee/core/src/application/contracts.ts
@@ -78,6 +78,7 @@ export const CartItemIdRequestSchema = Schema.Struct({
 export type CartItemIdRequest = typeof CartItemIdRequestSchema.Type;
 
 export const CheckoutCartRequestSchema = Schema.Struct({
+  checkoutSessionId: CheckoutSessionIdSchema,
   customerName: Schema.optionalKey(BoundaryStringSchema),
 }).annotate({ identifier: "CheckoutCartRequest" });
 export type CheckoutCartRequest = typeof CheckoutCartRequestSchema.Type;

--- a/packages/coffee/core/src/application/use-cases/cart.ts
+++ b/packages/coffee/core/src/application/use-cases/cart.ts
@@ -1,4 +1,5 @@
 import * as Arr from "effect/Array";
+import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
@@ -6,7 +7,7 @@ import * as Schema from "effect/Schema";
 import type { DrinkNotFoundError, InvalidOrderInputError } from "../../domain/errors.ts";
 import type { Cart, CartItem } from "../../domain/cart.ts";
 import { sumMoney } from "../../domain/money.ts";
-import type { CoffeeOrder } from "../../domain/order.ts";
+import type { CoffeeOrder, CoffeeOrderItem } from "../../domain/order.ts";
 import { AuthenticationRequiredError, requireSignedInActor } from "../CurrentActor.ts";
 import type {
   CartItemIdRequest,
@@ -19,6 +20,7 @@ import { OrderItemsInputSchema } from "../contracts.ts";
 import { InternalAppError, internalAppErrorFromPersistence } from "../errors.ts";
 import { CartItemIdGenerator } from "../ports/CartItemIdGenerator.ts";
 import { CartRepository } from "../ports/CartRepository.ts";
+import { CheckoutSessionRepository } from "../ports/CheckoutSessionRepository.ts";
 import { MenuRepository } from "../ports/MenuRepository.ts";
 import { OrderIdGenerator } from "../ports/OrderIdGenerator.ts";
 import { OrderRepository } from "../ports/OrderRepository.ts";
@@ -217,25 +219,62 @@ export const clearCart = Effect.fn("CoffeeOrders.clearCart")(function* (): Effec
   return yield* toSnapshot(cleared);
 });
 
+const toOrderItemInputFromResolvedItem = (item: CoffeeOrderItem): OrderItemInput => ({
+  drinkId: item.drinkId,
+  size: item.size,
+  milk: item.milk,
+  temperature: item.temperature,
+  shots: item.shots,
+  quantity: item.quantity,
+  ...Option.match(item.notes, {
+    onNone: () => ({}),
+    onSome: (notes) => ({ notes }),
+  }),
+});
+
 export const checkoutCart = Effect.fn("CoffeeOrders.checkoutCart")(function* (
   input: CheckoutCartRequest,
 ): Effect.fn.Return<
   CoffeeOrder,
   AuthenticationRequiredError | DrinkNotFoundError | InvalidOrderInputError | InternalAppError,
-  CartRepository | MenuRepository | OrderIdGenerator | OrderRepository
+  CartRepository | CheckoutSessionRepository | MenuRepository | OrderIdGenerator | OrderRepository
 > {
-  const cart = yield* readActorCart();
+  const actor = yield* requireSignedInActor();
+  const checkoutSessionRepository = yield* CheckoutSessionRepository;
+  const sessionOption = yield* checkoutSessionRepository
+    .getById(input.checkoutSessionId)
+    .pipe(
+      Effect.mapError(internalAppErrorFromPersistence("Unable to load checkout session right now")),
+    );
+  const session = yield* sessionOption.pipe(
+    Option.match({
+      onNone: () =>
+        Effect.fail(invalidOrderInput(`checkout session ${input.checkoutSessionId} was not found`)),
+      onSome: Effect.succeed,
+    }),
+  );
 
-  yield* Effect.succeed(cart.items).pipe(
+  yield* Effect.succeed(session).pipe(
     Effect.filterOrFail(
-      (items) => items.length > 0,
-      () => invalidOrderInput("cart must include at least one item"),
+      (checkoutSession) => checkoutSession.ownerUserId === actor.userId,
+      () => invalidOrderInput(`checkout session ${input.checkoutSessionId} was not found`),
     ),
   );
 
-  const items = yield* decodeOrderItemsInput(cart.items.map(toOrderItemInput)).pipe(
+  const now = yield* DateTime.now;
+  yield* Effect.succeed(session).pipe(
+    Effect.filterOrFail(
+      (checkoutSession) =>
+        DateTime.toEpochMillis(checkoutSession.expiresAt) >= DateTime.toEpochMillis(now),
+      () => invalidOrderInput(`checkout session ${input.checkoutSessionId} has expired`),
+    ),
+  );
+
+  const items = yield* decodeOrderItemsInput(
+    session.items.map(toOrderItemInputFromResolvedItem),
+  ).pipe(
     Effect.catchTag("SchemaError", () =>
-      Effect.fail(invalidOrderInput("cart must include at least one item")),
+      Effect.fail(invalidOrderInput("checkout session must include at least one item")),
     ),
   );
   const order = yield* placeOrder({
@@ -247,8 +286,15 @@ export const checkoutCart = Effect.fn("CoffeeOrders.checkoutCart")(function* (
   });
   const cartRepository = yield* CartRepository;
   yield* cartRepository
-    .clear(cart.ownerUserId)
+    .clear(actor.userId)
     .pipe(Effect.mapError(internalAppErrorFromPersistence("Unable to clear cart right now")));
+  yield* checkoutSessionRepository
+    .clearCurrentByOwnerUserId(actor.userId)
+    .pipe(
+      Effect.mapError(
+        internalAppErrorFromPersistence("Unable to clear checkout session right now"),
+      ),
+    );
 
   return order;
 });


### PR DESCRIPTION
## ELI5

#60 creates a checkout session, but by itself the final checkout tool could still be called without naming that session. This PR makes the checkout session act like the claim ticket for the purchase.

In normal words: the assistant has to say, "I am placing this specific checkout session," instead of just saying, "buy whatever is in the cart." That makes the confirmation step much harder to skip or misunderstand.

## Why This Is Valuable

- Turns confirmation from vibes into a concrete id-backed action.
- Prevents bare checkout_cart calls from placing an order without a prepared checkout session.
- Keeps the flow aligned with Cart -> CheckoutSession -> Order.
- Clears both the cart and current checkout session after a successful purchase, so stale confirmations do not hang around.

## What Changed

- checkout_cart now requires checkoutSessionId.
- checkoutCart loads the session, verifies it belongs to the signed-in actor, rejects expired/missing sessions, then places the order.
- Assistant instructions now tell the model to call get_checkout_session and pass that id to checkout_cart.
- Cart tests now cover successful session-backed checkout and rejection of an unknown session id.

## Verification

Empirically verified with:

- bun run check:affected
- focused backend test run: 10 files, 61 tests passed
- focused package typechecks for core/actions/assistant/auth/MCP passed

Note: check:affected completed successfully. It reported existing warning-level custom-lint/fallow duplication findings, but no failing gates.