### PR TITLE
refactor(sqlite): introduce Cloudflare D1 boundary service

### DIFF
--- a/packages/coffee/external/sqlite/src/cloudflare/live.ts
+++ b/packages/coffee/external/sqlite/src/cloudflare/live.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import { D1Client } from "@effect/sql-d1";
+import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { createD1Client } from "sqlfu";
@@ -7,14 +8,38 @@ import { migrate } from "../sql/migrations/.generated/migrations.ts";
 import { SqlCoffeeAppLive } from "../sql/live.ts";
 import { SqlCoffeeSchemaReady } from "../sql/schema-ready.ts";
 
+const schemaReady = { ready: true } satisfies { readonly ready: true };
+
+export class CoffeeDatabase extends Context.Service<CoffeeDatabase, D1Database>()(
+  "effect-coffee-shop/cloudflare/CoffeeDatabase",
+) {}
+
+export const makeCloudflareCoffeeDatabaseLive = (db: D1Database) =>
+  Layer.succeed(CoffeeDatabase, db);
+
+export const CloudflareCoffeeD1SqlLive = Layer.unwrap(
+  Effect.gen(function* () {
+    const db = yield* CoffeeDatabase;
+    return D1Client.layer({ db });
+  }),
+);
+
+export const CloudflareSqlCoffeeSchemaLive = Layer.effect(
+  SqlCoffeeSchemaReady,
+  Effect.gen(function* () {
+    const db = yield* CoffeeDatabase;
+    return yield* Effect.promise(async () => migrate(createD1Client(db))).pipe(
+      Effect.as(schemaReady),
+    );
+  }),
+);
+
 export const makeCloudflareSqlCoffeeSchemaLive = (db: D1Database) =>
-  Layer.effect(
-    SqlCoffeeSchemaReady,
-    Effect.promise(async () => migrate(createD1Client(db))).pipe(Effect.as({ ready: true })),
-  );
+  CloudflareSqlCoffeeSchemaLive.pipe(Layer.provide(makeCloudflareCoffeeDatabaseLive(db)));
 
 export const makeCloudflareCoffeeAppLive = (db: D1Database) =>
   SqlCoffeeAppLive.pipe(
-    Layer.provide(D1Client.layer({ db })),
-    Layer.provide(makeCloudflareSqlCoffeeSchemaLive(db)),
+    Layer.provide(CloudflareCoffeeD1SqlLive),
+    Layer.provide(CloudflareSqlCoffeeSchemaLive),
+    Layer.provide(makeCloudflareCoffeeDatabaseLive(db)),
   );


### PR DESCRIPTION
- Adds `CoffeeDatabase` as a `Context.Service` boundary for the Cloudflare D1 binding, following Effect's documented `Context` and `Layer` dependency model.[^effect-context][^effect-layer]
- Composes both `CloudflareCoffeeD1SqlLive` and `CloudflareSqlCoffeeSchemaLive` from that same D1 boundary so SQL access and migrations share one source of truth.[^cloudflare-d1]
- Preserves the existing raw `D1Database` factory APIs for backend and auth callers while making the Cloudflare edge binding explicit.
- Keeps the PR title in Conventional Commit format: `refactor(sqlite): introduce Cloudflare D1 boundary service`.[^conventional-commits]
- Validation: pre-commit hooks passed `oxfmt check`, `oxlint`, `lintcn`, and `typecheck`; push hook passed affected quality checks.

[^conventional-commits]: https://www.conventionalcommits.org/en/v1.0.0/
[^cloudflare-d1]: https://developers.cloudflare.com/d1/
[^effect-context]: https://effect-ts.github.io/effect/effect/Context.ts.html
[^effect-layer]: https://effect-ts.github.io/effect/effect/Layer.ts.html