### PR TITLE
chore: upgrade alchemy to v2.0.0-beta.43

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -12,7 +12,7 @@
         "@j178/prek": "0.4.0",
         "@mpsuesser/oxlint-plugin-effect": "^0.1.0",
         "@typescript/native-preview": "7.0.0-dev.20260518.1",
-        "alchemy": "2.0.0-beta.40",
+        "alchemy": "2.0.0-beta.43",
         "effect": "4.0.0-beta.67",
         "fallow": "catalog:",
         "turbo": "^2.9.14",
@@ -556,6 +556,8 @@
     "@distilled.cloud/core": ["@distilled.cloud/core@0.21.3", "", { "peerDependencies": { "effect": ">=4.0.0-beta.66 || >=4.0.0" } }, "sha512-REseF2izjkHiGwiGydV6zyUa6/1IhkqGcX2G7WVdqJ7lMWi6csLYzreYniFdEcPGw6UIONcu5GrW0qxjArpVJA=="],
 
     "@distilled.cloud/neon": ["@distilled.cloud/neon@0.21.3", "", { "dependencies": { "@distilled.cloud/core": "0.21.3" }, "peerDependencies": { "effect": ">=4.0.0-beta.66 || >=4.0.0" } }, "sha512-WzXrUjLTrtjDcxk2g+qOt8YpOT39LC+wc7JbbY6XA52mjL8B/dduxgv2WhGV8FdFzG/tuI/CacK5eBR1VF2fJw=="],
+
+    "@distilled.cloud/planetscale": ["@distilled.cloud/planetscale@0.21.3", "", { "dependencies": { "@distilled.cloud/core": "0.21.3" }, "peerDependencies": { "effect": ">=4.0.0-beta.66 || >=4.0.0" } }, "sha512-dUsgEbwyb+gdGcM+X1DZzoOorPQp0kYf8TF63xxqBtsaNK9YN8ppn0uiyM2AkSESPlonOuEOpdX8SXuMIuDFIQ=="],
 
     "@drizzle-team/brocli": ["@drizzle-team/brocli@0.11.0", "", {}, "sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg=="],
 
@@ -1557,7 +1559,7 @@
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
-    "alchemy": ["alchemy@2.0.0-beta.40", "", { "dependencies": { "@alchemy.run/node-utils": "0.0.2", "@aws-sdk/credential-providers": "^3.0.0", "@clack/prompts": "^0.11.0", "@distilled.cloud/aws": "^0.21.0", "@distilled.cloud/axiom": "^0.21.0", "@distilled.cloud/cloudflare": "^0.21.0", "@distilled.cloud/cloudflare-rolldown-plugin": "0.5.4", "@distilled.cloud/cloudflare-runtime": "0.5.4", "@distilled.cloud/cloudflare-vite-plugin": "0.5.4", "@distilled.cloud/core": "^0.21.0", "@distilled.cloud/neon": "^0.21.0", "@effect/vitest": ">=4.0.0-beta.66 || >=4.0.0", "@libsql/client": "^0.17.0", "@octokit/rest": "^22.0.1", "@smithy/node-config-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.3.4", "@smithy/types": "^4.8.1", "@types/aws-lambda": "^8.10.152", "aws4fetch": "^1.0.20", "capnweb": "^0.6.1", "fast-glob": "^3.3.2", "fast-xml-parser": "^5.3.4", "foreground-child": "^4.0.3", "ink": "^6.3.1", "jszip": "^3.10.1", "libsodium-wrappers": "^0.8.3", "magic-string": "^0.30.21", "pathe": "^2.0.3", "pg": "^8.13.0", "picomatch": "^4.0.4", "react": "^19.2.0", "rolldown": "1.0.0-rc.17", "sonda": "^0.11.1", "undici": "^7.16.0", "yaml": "^2.0.0" }, "peerDependencies": { "@effect/platform-bun": ">=4.0.0-beta.66 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.66 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.66 || >=4.0.0", "drizzle-kit": ">=1.0.0-rc.1", "drizzle-orm": ">=1.0.0-rc.1", "effect": ">=4.0.0-beta.66 || >=4.0.0", "vite": "^8.0.7", "ws": "^8.20.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node", "@effect/sql-pg", "drizzle-kit", "drizzle-orm", "vite", "ws"], "bin": { "alchemy": "bin/cli.js" } }, "sha512-GKIBhItlSFUQSVumz30Wb72CDxAp6xHx/rBbGMFUQ8dzh7B+fE42wbaW8gZVQ0tF8EICDB1Wha7Z+yqn1U3g+A=="],
+    "alchemy": ["alchemy@2.0.0-beta.43", "", { "dependencies": { "@alchemy.run/node-utils": "0.0.2", "@aws-sdk/credential-providers": "^3.0.0", "@clack/prompts": "^0.11.0", "@distilled.cloud/aws": "^0.21.3", "@distilled.cloud/axiom": "^0.21.3", "@distilled.cloud/cloudflare": "^0.21.3", "@distilled.cloud/cloudflare-rolldown-plugin": "0.5.4", "@distilled.cloud/cloudflare-runtime": "0.5.4", "@distilled.cloud/cloudflare-vite-plugin": "0.5.4", "@distilled.cloud/core": "^0.21.3", "@distilled.cloud/neon": "^0.21.3", "@distilled.cloud/planetscale": "^0.21.3", "@effect/vitest": ">=4.0.0-beta.66 || >=4.0.0", "@libsql/client": "^0.17.0", "@octokit/rest": "^22.0.1", "@smithy/node-config-provider": "^4.0.0", "@smithy/shared-ini-file-loader": "^4.3.4", "@smithy/types": "^4.8.1", "@types/aws-lambda": "^8.10.152", "aws4fetch": "^1.0.20", "capnweb": "^0.6.1", "fast-glob": "^3.3.2", "fast-xml-parser": "^5.3.4", "foreground-child": "^4.0.3", "ink": "^6.3.1", "jszip": "^3.10.1", "libsodium-wrappers": "^0.8.3", "magic-string": "^0.30.21", "mysql2": "^3.15.3", "pathe": "^2.0.3", "pg": "^8.13.0", "picomatch": "^4.0.4", "react": "^19.2.0", "rolldown": "1.0.0-rc.17", "sonda": "^0.11.1", "undici": "^7.16.0", "yaml": "^2.0.0" }, "peerDependencies": { "@effect/platform-bun": ">=4.0.0-beta.66 || >=4.0.0", "@effect/platform-node": ">=4.0.0-beta.66 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.66 || >=4.0.0", "drizzle-kit": ">=1.0.0-rc.1", "drizzle-orm": ">=1.0.0-rc.1", "effect": ">=4.0.0-beta.66 || >=4.0.0", "vite": "^8.0.7", "ws": "^8.20.0" }, "optionalPeers": ["@effect/platform-bun", "@effect/platform-node", "@effect/sql-pg", "drizzle-kit", "drizzle-orm", "vite", "ws"], "bin": { "alchemy": "bin/cli.js" } }, "sha512-FcDH97nTArtkw80eHcrBId9s90orvH6GLel+aahhvwMrlzSn5Sp9fMc1Z+9/Nl7KPhaLXHe+rJp5LGvtDhWp4Q=="],
 
     "ansi-escapes": ["ansi-escapes@7.3.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg=="],
 
@@ -1576,6 +1578,8 @@
     "ast-types": ["ast-types@0.16.1", "", { "dependencies": { "tslib": "^2.0.1" } }, "sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg=="],
 
     "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
+    "aws-ssl-profiles": ["aws-ssl-profiles@1.1.2", "", {}, "sha512-NZKeq9AfyQvEeNlN0zSYAaWrmBffJh3IELMZfRpJVWgrpEbtEpnjvzqBPf+mxoI287JohRDoa+/nsfqqiZmF6g=="],
 
     "aws4fetch": ["aws4fetch@1.0.20", "", {}, "sha512-/djoAN709iY65ETD6LKCtyyEI04XIBP5xVvfmNxsEP0uJB5tyaGBztSryRr4HqMStr9R06PisQE7m9zDTXKu6g=="],
 
@@ -1775,6 +1779,8 @@
 
     "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
 
+    "generate-function": ["generate-function@2.3.1", "", { "dependencies": { "is-property": "^1.0.2" } }, "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ=="],
+
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.6.0", "", {}, "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA=="],
@@ -1798,6 +1804,8 @@
     "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
 
     "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -1832,6 +1840,8 @@
     "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
+
+    "is-property": ["is-property@1.0.2", "", {}, "sha512-Ks/IoX00TtClbGQr4TWXemAnktAQvYB7HzcCxDGqEZU6oCmb2INHuOoKxbtR+HFkmYWBKv/dOZtGRiAjDhj92g=="],
 
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
@@ -1913,9 +1923,13 @@
 
     "lodash.isarguments": ["lodash.isarguments@3.1.0", "", {}, "sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg=="],
 
+    "long": ["long@5.3.2", "", {}, "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA=="],
+
     "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
+    "lru.min": ["lru.min@1.1.4", "", {}, "sha512-DqC6n3QQ77zdFpCMASA1a3Jlb64Hv2N2DciFGkO/4L9+q/IpIAuRlKOvCXabtRW6cQf8usbmM6BE/TOPysCdIA=="],
 
     "lucide-react": ["lucide-react@1.16.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ=="],
 
@@ -1952,6 +1966,10 @@
     "msgpackr-extract": ["msgpackr-extract@3.0.3", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.3", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.3", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.3" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-P0efT1C9jIdVRefqjzOQ9Xml57zpOXnIuS+csaB4MdZbTdmGDLo8XhzBG1N7aO11gKDDkJvBLULeFTo46wwreA=="],
 
     "multipasta": ["multipasta@0.2.7", "", {}, "sha512-KPA58d68KgGil15oDqXjkUBEBYc00XvbPj5/X+dyzeo/lWm9Nc25pQRlf1D+gv4OpK7NM0J1odrbu9JNNGvynA=="],
+
+    "mysql2": ["mysql2@3.22.3", "", { "dependencies": { "aws-ssl-profiles": "^1.1.2", "denque": "^2.1.0", "generate-function": "^2.3.1", "iconv-lite": "^0.7.2", "long": "^5.3.2", "lru.min": "^1.1.4", "named-placeholders": "^1.1.6", "sql-escaper": "^1.3.3" }, "peerDependencies": { "@types/node": ">= 8" } }, "sha512-uWWxvZSRvRhtBdh2CdcuK83YcOfPdmEeEYB069bAmPnV93QApDGVPuvCQOLjlh7tYHEWdgQPrn6kosDxHBVLkA=="],
+
+    "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
     "nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
@@ -2127,6 +2145,8 @@
 
     "safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
@@ -2160,6 +2180,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sql-escaper": ["sql-escaper@1.3.3", "", {}, "sha512-BsTCV265VpTp8tm1wyIm1xqQCS+Q9NHx2Sr+WcnUrgLrQ6yiDIvHYJV5gHxsj1lMBy2zm5twLaZao8Jd+S8JJw=="],
 
     "sqlfu": ["sqlfu@0.0.3-14", "", { "dependencies": { "@clack/prompts": "^1.2.0", "@orpc/server": "^1.13.13", "trpc-cli": "^0.14.0", "zod": "^4.3.6" }, "peerDependencies": { "@effect/sql": "^0.51.1", "@sqlfu/ui": "0.0.3-14", "better-auth": "^1.6.9", "effect": "^3.21.2 || ^4.0.0-beta.60" }, "optionalPeers": ["@effect/sql", "@sqlfu/ui", "better-auth", "effect"], "bin": { "sqlfu": "bin/sqlfu.js" } }, "sha512-0JHD+oksVx2OEbrgFjBmN+nB4Y1q7jkkbHhAVytG/ZzzOcHwmtbxB8Q8Iz7euJ2R28LSTNqS5VfuyBkdZQ8aYQ=="],
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -2,3 +2,5 @@
 linker = "isolated"
 globalStore = true
 minimumReleaseAge = 259200
+# Bun 1.3.11 only honors package-level release-age exclusions.
+minimumReleaseAgeExcludes = ["alchemy"]

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "@j178/prek": "0.4.0",
     "@mpsuesser/oxlint-plugin-effect": "^0.1.0",
     "@typescript/native-preview": "7.0.0-dev.20260518.1",
-    "alchemy": "2.0.0-beta.40",
+    "alchemy": "2.0.0-beta.43",
     "effect": "4.0.0-beta.67",
     "fallow": "catalog:",
     "turbo": "^2.9.14"


### PR DESCRIPTION
## Summary

Adopts `alchemy@2.0.0-beta.43` for the Coffee Shop Alchemy stack.

- Upgrades `alchemy` from `2.0.0-beta.40` to `2.0.0-beta.43`
- Regenerates `bun.lock`
- Adds `alchemy` to Bun's `minimumReleaseAgeExcludes` because this workspace intentionally tracks new Alchemy v2 betas

## Why Now

`v2.0.0-beta.41` through `v2.0.0-beta.43` include several Cloudflare Worker fixes that map directly to this repo's deployment shape:

- `Cloudflare.StaticSite` with a Worker backend
- D1 binding
- AI binding added via `website.bind(...)`
- scalar Worker env for AI Gateway, Better Auth, and staff allowlist config
- Worker routes for HTTP API, MCP, auth, assistant, and assets

I also explored the `alchemy-run/alchemy-effect` repository at tag `v2.0.0-beta.43` with Nia. The especially relevant files were:

- `packages/alchemy/src/Cloudflare/Workers/Worker.ts`
- `packages/alchemy/src/Cloudflare/Workers/InferEnv.ts`
- `packages/alchemy/src/Cloudflare/Workers/WorkerBinding.ts`
- `packages/alchemy/src/Sidecar/RpcHandler.ts`

## Notable Upstream Changes

| Release | Change | Relevance |
| --- | --- | --- |
| `v2.0.0-beta.41` | Include `WorkerProps.env` in `InferEnv` | Better type coverage for the env values we pass into the Worker from `alchemy.run.ts`. |
| `v2.0.0-beta.41` | Scope RPC and HTTP runtime Effects per request | Important for our single Worker entrypoint that serves HTTP API, MCP, auth, assistant, and assets. |
| `v2.0.0-beta.41` | Externalize `lightningcss` and `fsevents` in Worker bundler | Reduces native/optional package bundling risk around the Vite/Cloudflare Worker build path. |
| `v2.0.0-beta.41` | Preserve `Redacted` values across sidecar RPC serialization | Relevant to Better Auth secrets and generated Alchemy secrets during local/dev workflows. |
| `v2.0.0-beta.42` | Defer Worker Platform hook bindings to avoid npm TDZ import-cycle failure | Directly relevant because this repo consumes Alchemy from npm. |
| `v2.0.0-beta.43` | Move Worker binding environment requirements to Layers | Makes runtime binding access more compatible with layered Effect code. |
| `v2.0.0-beta.43` | Allow `Output`s as input to `Cloudflare.Worker` | Useful for composing Worker config from other Alchemy resource outputs. |
| `v2.0.0-beta.43` | Remove actions when destroying | Better lifecycle cleanup for future deploy-time actions. |
| `v2.0.0-beta.43` | Add PlanetScale resources | Not adopted here yet, but now available for future persistence experiments. |

## Adopt Next

<details>
<summary>1. Tighten the Cloudflare Worker env contract around Alchemy InferEnv</summary>

### Proposal

Use the improved Worker env typing to reduce drift between:

- env values declared in `alchemy.run.ts`
- `CloudflareWorkerEnv` in `apps/backend/src/platforms/cloudflare/env.ts`
- runtime config decoding in `readCloudflareRuntime`

The Alchemy tag now models Worker env explicitly through `WorkerProps<Bindings, Env, Assets>` and `env?: Env`, so we should make our deployment env object a named value with a narrow shape.

### Candidate snippet

```ts
// alchemy.run.ts
type CoffeeWorkerScalarEnv = {
  readonly [cloudflareEnvNames.aiGatewayId]: string;
  readonly [cloudflareEnvNames.betterAuthSecret]: Redacted.Redacted<string> | "";
  readonly [cloudflareEnvNames.coffeeStaffUserIds]: string;
};

const coffeeWorkerEnv = yield* Effect.gen(function* () {
  return {
    [cloudflareEnvNames.aiGatewayId]: assistantGateway?.gatewayId ?? "",
    [cloudflareEnvNames.betterAuthSecret]: yield* betterAuthSecret,
    [cloudflareEnvNames.coffeeStaffUserIds]:
      process.env[cloudflareEnvNames.coffeeStaffUserIds] ?? "",
  } satisfies CoffeeWorkerScalarEnv;
});
```

The exact type shape may need adjustment after checking Alchemy's exported names, but the goal is to name the boundary once and keep `readCloudflareRuntime` as the runtime decoder.

### Expected benefit

Fewer silent deployment/runtime mismatches when adding Worker env values, especially around assistant and auth config.

</details>

<details>
<summary>2. Revisit AI binding declaration now that Worker binding/runtime fixes landed</summary>

### Proposal

Review whether the post-create `website.bind(cloudflareBindingNames.ai, ...)` call can move into a more declarative binding shape or be wrapped in a local helper that matches the current Alchemy Worker binding model.

Alchemy's `v2.0.0-beta.43` Worker binding code resolves service bindings lazily from `WorkerEnvironment`, and the Worker docs in the tag emphasize declaring runtime resources through `bindings`.

### Candidate snippet

```ts
// Preferred if Alchemy supports this binding shape for AI:
const website = yield* Cloudflare.StaticSite("onion", {
  // ...
  bindings: {
    [cloudflareBindingNames.db]: coffeeDb,
    [cloudflareBindingNames.ai]: {
      bindings: [{ type: "ai", name: cloudflareBindingNames.ai }],
    },
  },
});
```

If `StaticSite` still does not accept the raw AI binding in `bindings`, keep the post-create call but isolate the reason:

```ts
const bindWorkersAi = (
  worker: Cloudflare.Worker,
): Effect.Effect<void> =>
  worker.bind(cloudflareBindingNames.ai, {
    bindings: [{ type: "ai", name: cloudflareBindingNames.ai }],
  });

yield* bindWorkersAi(website);
```

### Expected benefit

Cleaner stack declaration and fewer surprises around binding availability in local sidecar and remote Worker execution.

</details>

<details>
<summary>3. Exercise request-scoped runtime fixes with focused Worker integration tests</summary>

### Proposal

Add or extend Miniflare/Worker tests that run multiple routes in sequence and verify state/config does not bleed across requests.

This targets the upstream fix for RPC/HTTP APIs being scoped per request. Our Worker multiplexes auth, MCP, assistant, API, and assets, so this is the most important behavioral regression test to add after the dependency upgrade.

### Candidate snippet

```ts
it("routes repeated Cloudflare requests without cross-request runtime leakage", async () => {
  await withTestEnv(async ({ assetsFetch, env }) => {
    const fetchWorker = (path: string) =>
      worker.fetch(
        new Request(`http://example.com${path}`),
        env,
        executionContext,
      );

    const health = await fetchWorker("/api/health");
    const session = await fetchWorker("/api/auth/session");
    const home = await fetchWorker("/");

    expect(health.status).toBe(200);
    expect(session.status).not.toBe(500);
    expect(home.status).toBe(200);
    expect(assetsFetch).toHaveBeenCalled();
  });
});
```

### Expected benefit

Regression coverage for the exact class of Alchemy fix in `v2.0.0-beta.41`: runtime Effect initialization and scoping per request.

</details>

<details>
<summary>4. Add an explicit local-dev secret serialization smoke test</summary>

### Proposal

Verify that `Redacted` secrets generated or supplied in `alchemy.run.ts` survive local sidecar serialization as actual secret values rather than `"<redacted>"`.

Nia inspection of `packages/alchemy/src/Sidecar/RpcHandler.ts` at `v2.0.0-beta.43` shows Alchemy now pre-walks RPC arguments with an `encodeRedacted` function before `JSON.stringify`.

### Relevant upstream shape

```ts
const encodeRedacted = (value: unknown): unknown => {
  if (Redacted.isRedacted(value)) {
    return { _tag: "Redacted", value: Redacted.value(value) };
  }
  if (Array.isArray(value)) {
    return value.map(encodeRedacted);
  }
  if (value && typeof value === "object" && !("toJSON" in value)) {
    return Object.fromEntries(
      Object.entries(value).map(([key, child]) => [key, encodeRedacted(child)]),
    );
  }
  return value;
};
```

### Candidate local smoke

```ts
it("does not expose redacted Cloudflare env as the placeholder string", () => {
  const env = {
    ...baseEnv,
    BETTER_AUTH_SECRET: "test-secret",
  } satisfies CloudflareWorkerEnv;

  const runtime = readCloudflareRuntime(env);

  expect(revealSecret(runtime.config.betterAuthSecret)).toBe("test-secret");
  expect(revealSecret(runtime.config.betterAuthSecret)).not.toBe("<redacted>");
});
```

### Expected benefit

Confidence that Better Auth and future secret-backed resources behave correctly in `alchemy dev`.

</details>

<details>
<summary>5. Evaluate deploy-time Actions for database setup tasks</summary>

### Proposal

Now that destroy removes actions cleanly, consider using Alchemy Actions for deploy-time operational work that is currently manual or implicit.

### Candidate uses

- D1 migration verification before deploy completes
- post-deploy health check against the Worker URL
- optional seed data for local preview/staging stacks

### Candidate snippet

```ts
// Sketch: confirm the exact Action constructor/API before implementation.
const verifyD1Migrations = yield* Alchemy.Action("verify-d1-migrations", {
  input: {
    migrationsDir: "./packages/coffee/external/sqlite/src/sql/migrations",
    databaseName: coffeeDb.databaseName,
  },
  run: ({ input }) =>
    Effect.gen(function* () {
      // Keep this idempotent: verify migration files and DB metadata only.
      yield* Effect.logInfo(`Verifying migrations for ${input.databaseName}`);
    }),
});

// A downstream resource can depend on the action output if needed.
void verifyD1Migrations;
```

### Guardrails

- Actions should be idempotent or retry-tolerant.
- Do not move normal application behavior into deploy-time actions.
- Keep D1 schema ownership in the existing migration files.

### Expected benefit

More explicit deploy workflow without smuggling one-off work into app startup.

</details>

<details>
<summary>6. Keep PlanetScale as a tracked option, not an immediate migration</summary>

### Proposal

Document PlanetScale as a potential future backend, but do not move Coffee Shop off D1 as part of this upgrade.

The new package pulls `@distilled.cloud/planetscale` and `mysql2` into the lockfile, and the Alchemy tag adds `Planetscale` resources. That is useful optional surface area, not a reason to change the current architecture.

### Candidate spike shape

```ts
// experiments/planetscale/alchemy.run.ts
import * as Alchemy from "alchemy";
import * as Planetscale from "alchemy/Planetscale";

export default Alchemy.Stack("coffee-planetscale-spike", {}, Effect.gen(function* () {
  const database = yield* Planetscale.Database("coffee");
  const branch = yield* Planetscale.Branch("preview", {
    database,
  });

  return {
    database: database.name,
    branch: branch.name,
  };
}));
```

### Expected benefit

Keeps the option visible while preserving D1 as the production persistence path.

</details>

## Verification

- `bun install`
- `bun install --frozen-lockfile`
- `bunx alchemy --version` -> `alchemy v2.0.0-beta.43`
- `bun run typecheck:affected`
- commit hooks: `oxfmt`, `oxlint`, `lintcn`, `typecheck`
- push hook: affected quality checks

## Sources

- https://github.com/alchemy-run/alchemy-effect/releases/tag/v2.0.0-beta.41
- https://github.com/alchemy-run/alchemy-effect/releases/tag/v2.0.0-beta.42
- https://github.com/alchemy-run/alchemy-effect/releases/tag/v2.0.0-beta.43
- Nia indexed source: `alchemy-run/alchemy-effect:v2.0.0-beta.43`
