### PR TITLE
docs: add package README and module TSDoc coverage

### DIFF
--- a/alchemy.run.ts
+++ b/alchemy.run.ts
@@ -1,1 +1,6 @@
+/**
+ * Selects the default Alchemy deployment stack for this workspace.
+ *
+ * @module
+ */
 export { default } from "./infra/alchemy/cloudflare.ts";

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -6,19 +6,28 @@ It chooses concrete persistence, auth, host, and presentation layers for deploya
 library packages define reusable Coffee behavior and adapters; this app decides how those pieces are
 assembled for Bun, Cloudflare Workers, and AWS Lambda.
 
+See [`../../packages`](../../packages) for the package map this app composes.
+
 ## Runtime Surfaces
 
-- `src/platforms/bun`: local HTTP, CLI, MCP stdio, MCP HTTP, and local development entrypoints.
-- `src/platforms/cloudflare`: Worker runtime composition, Cloudflare environment decoding, static
-  asset routing, D1 persistence, auth, assistant, HTTP API, and MCP mounts.
-- `src/platforms/aws`: Lambda and router composition for AWS deployments.
-- `src/host`: shared Fetch-runtime mount wiring used by platform-specific shells.
-- `src/app-layer.ts`: default persistent Coffee application layer for local backend entrypoints.
+- [`src/platforms/bun`](./src/platforms/bun): local HTTP, CLI, MCP stdio, MCP HTTP, and local
+  development entrypoints.
+- [`src/platforms/cloudflare`](./src/platforms/cloudflare): Worker runtime composition, Cloudflare
+  environment decoding, static asset routing, D1 persistence, auth, assistant, HTTP API, and MCP
+  mounts.
+- [`src/platforms/aws`](./src/platforms/aws): Lambda and router composition for AWS deployments.
+- [`src/host`](./src/host): shared Fetch-runtime mount wiring used by platform-specific shells.
+- [`src/app-layer.ts`](./src/app-layer.ts): default persistent Coffee application layer for local
+  backend entrypoints.
 
 ## Boundary Rule
 
-Runtime-specific binding decoding and layer composition belong here. Domain rules, application use
-cases, action contracts, and presentation protocol definitions stay in their package workspaces.
+Runtime-specific binding decoding and layer composition belong here. Domain rules and application use
+cases stay in [`coffee-core`](../../packages/coffee/core), action contracts stay in
+[`coffee-actions`](../../packages/coffee/actions), and presentation protocol definitions stay in the
+[`coffee-http`](../../packages/coffee/presentation/http),
+[`coffee-mcp`](../../packages/coffee/presentation/mcp), and
+[`coffee-cli`](../../packages/coffee/presentation/cli).
 
 ## Commands
 
@@ -35,7 +44,8 @@ bun run --cwd apps/backend lint:custom
 bun run --cwd apps/backend fmt:check
 ```
 
-Database helper commands proxy to the SQLite external package:
+Database helper commands proxy to the
+[`SQLite external package`](../../packages/coffee/external/sqlite):
 
 ```bash
 bun run --cwd apps/backend db:check

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -1,0 +1,44 @@
+# Backend App
+
+`@effect-coffee-shop/backend` is the composition root for backend runtimes.
+
+It chooses concrete persistence, auth, host, and presentation layers for deployable entrypoints. The
+library packages define reusable Coffee behavior and adapters; this app decides how those pieces are
+assembled for Bun, Cloudflare Workers, and AWS Lambda.
+
+## Runtime Surfaces
+
+- `src/platforms/bun`: local HTTP, CLI, MCP stdio, MCP HTTP, and local development entrypoints.
+- `src/platforms/cloudflare`: Worker runtime composition, Cloudflare environment decoding, static
+  asset routing, D1 persistence, auth, assistant, HTTP API, and MCP mounts.
+- `src/platforms/aws`: Lambda and router composition for AWS deployments.
+- `src/host`: shared Fetch-runtime mount wiring used by platform-specific shells.
+- `src/app-layer.ts`: default persistent Coffee application layer for local backend entrypoints.
+
+## Boundary Rule
+
+Runtime-specific binding decoding and layer composition belong here. Domain rules, application use
+cases, action contracts, and presentation protocol definitions stay in their package workspaces.
+
+## Commands
+
+```bash
+bun run --cwd apps/backend http
+bun run --cwd apps/backend cli
+bun run --cwd apps/backend mcp:stdio
+bun run --cwd apps/backend mcp:http
+bun run --cwd apps/backend dev:local:api
+bun run --cwd apps/backend test
+bun run --cwd apps/backend typecheck
+bun run --cwd apps/backend lint
+bun run --cwd apps/backend lint:custom
+bun run --cwd apps/backend fmt:check
+```
+
+Database helper commands proxy to the SQLite external package:
+
+```bash
+bun run --cwd apps/backend db:check
+bun run --cwd apps/backend db:generate
+bun run --cwd apps/backend db:migrate
+```

--- a/apps/backend/src/platforms/aws/mounts/http-api.ts
+++ b/apps/backend/src/platforms/aws/mounts/http-api.ts
@@ -1,3 +1,8 @@
+/**
+ * Mounts the Coffee HTTP API inside the AWS runtime.
+ *
+ * @module
+ */
 import { createAwsRequestServices } from "../coffee-backend.ts";
 import type { AwsRuntime } from "../env.ts";
 import { makeCoffeeHttpApiMount } from "../../../host/http-api-mount.ts";

--- a/apps/backend/src/platforms/cloudflare/mounts/http-api.ts
+++ b/apps/backend/src/platforms/cloudflare/mounts/http-api.ts
@@ -1,3 +1,8 @@
+/**
+ * Mounts the Coffee HTTP API inside the Cloudflare Worker runtime.
+ *
+ * @module
+ */
 import type { CloudflareWorkerEnv } from "../env.ts";
 import { createCloudflareRequestServices } from "../coffee-backend.ts";
 import { makeCoffeeHttpApiMount } from "../../../host/http-api-mount.ts";

--- a/apps/backend/src/platforms/env.ts
+++ b/apps/backend/src/platforms/env.ts
@@ -1,3 +1,8 @@
+/**
+ * Parses platform environment values shared across backend runtimes.
+ *
+ * @module
+ */
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";

--- a/apps/backend/src/platforms/env.ts
+++ b/apps/backend/src/platforms/env.ts
@@ -5,15 +5,10 @@
  */
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
-import * as Schema from "effect/Schema";
+import * as String from "effect/String";
 
-const decodeTrimmedString = Schema.decodeUnknownSync(Schema.Trim);
-
-export const optionalTrimmedString = (value: string | undefined): Option.Option<string> => {
-  const trimmed = decodeTrimmedString(value ?? "");
-
-  return Option.liftPredicate(trimmed, (input) => input !== "");
-};
+export const optionalTrimmedString = (value: string | undefined): Option.Option<string> =>
+  Option.fromUndefinedOr(value).pipe(Option.map(String.trim), Option.filter(String.isNonEmpty));
 
 export const optionalTrimmedRedactedString = (
   value: string | undefined,
@@ -34,12 +29,7 @@ export const trimOptionalRedactedString = (
   );
 
 export const parseCsvSet = (value: string | undefined): ReadonlySet<string> =>
-  new Set(
-    (value ?? "")
-      .split(",")
-      .map((entry) => decodeTrimmedString(entry))
-      .filter((entry) => entry !== ""),
-  );
+  new Set(String.split(value ?? "", ",").map(String.trim).filter(String.isNonEmpty));
 
 export const revealOptionalSecret = (
   secret: Option.Option<Redacted.Redacted<string>>,

--- a/apps/backend/src/platforms/env.ts
+++ b/apps/backend/src/platforms/env.ts
@@ -29,7 +29,11 @@ export const trimOptionalRedactedString = (
   );
 
 export const parseCsvSet = (value: string | undefined): ReadonlySet<string> =>
-  new Set(String.split(value ?? "", ",").map(String.trim).filter(String.isNonEmpty));
+  new Set(
+    String.split(value ?? "", ",")
+      .map(String.trim)
+      .filter(String.isNonEmpty),
+  );
 
 export const revealOptionalSecret = (
   secret: Option.Option<Redacted.Redacted<string>>,

--- a/infra/alchemy/config.ts
+++ b/infra/alchemy/config.ts
@@ -1,3 +1,8 @@
+/**
+ * Reads and validates Alchemy deployment configuration from environment variables.
+ *
+ * @module
+ */
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";

--- a/infra/alchemy/shared.ts
+++ b/infra/alchemy/shared.ts
@@ -1,3 +1,8 @@
+/**
+ * Shares deployment constants between Alchemy stacks.
+ *
+ * @module
+ */
 export const coffeeStackName = "effect-v4-onion";
 
 export const uiBuild = {

--- a/packages/README.md
+++ b/packages/README.md
@@ -6,33 +6,39 @@ under `packages/coffee`, while shared host utilities stay directly under
 
 ## Packages
 
-- `backend-host`: runtime-agnostic fetch host primitives, mount dispatch,
-  request logging, request-scoped services, JSON formatting, and the MCP HTTP
-  JSON-RPC id shim.
-- `coffee/core`: Coffee bounded-context Onion Core.
-- `coffee/external/in-memory`: in-memory Coffee External Layer.
-- `coffee/external/sqlite`: SQLFU-backed SQLite/D1 Coffee External Layer.
-- `coffee/external/drizzle-postgres`: Drizzle-backed Postgres Coffee External
-  Layer.
-- `coffee/actions`: shared coffee action contracts used by MCP tools,
-  assistant tools, and Agent Auth capability execution.
-- `coffee/presentation/http`: Effect HTTP API routes, web handler construction,
-  and the local Bun HTTP server.
-- `coffee/presentation/mcp`: MCP resources, prompts, tools, and stdio/HTTP MCP
-  Layers.
-- `coffee/presentation/cli`: CLI command tree over `CoffeeOrderApp`.
-- `coffee/assistant`: assistant request parsing, provider-neutral AI runtime,
-  Cloudflare and Ollama adapters, streaming chunks, and assistant tool projection.
-- `coffee/auth`: Better Auth runtime setup and delegated Agent Auth capability
-  execution.
+- [`backend-host`](./backend-host): runtime-agnostic fetch host primitives, mount
+  dispatch, request logging, request-scoped services, JSON formatting, and the
+  MCP HTTP JSON-RPC id shim.
+- [`coffee/core`](./coffee/core): Coffee bounded-context Onion Core.
+- [`coffee/external/in-memory`](./coffee/external/in-memory): in-memory Coffee
+  External Layer.
+- [`coffee/external/sqlite`](./coffee/external/sqlite): SQLFU-backed SQLite/D1
+  Coffee External Layer.
+- [`coffee/external/drizzle-postgres`](./coffee/external/drizzle-postgres):
+  Drizzle-backed Postgres Coffee External Layer.
+- [`coffee/actions`](./coffee/actions): shared coffee action contracts used by
+  MCP tools, assistant tools, and Agent Auth capability execution.
+- [`coffee/presentation/http`](./coffee/presentation/http): Effect HTTP API
+  routes, web handler construction, and the local Bun HTTP server.
+- [`coffee/presentation/mcp`](./coffee/presentation/mcp): MCP resources,
+  prompts, tools, and stdio/HTTP MCP Layers.
+- [`coffee/presentation/cli`](./coffee/presentation/cli): CLI command tree over
+  `CoffeeOrderApp`.
+- [`coffee/assistant`](./coffee/assistant): assistant request parsing,
+  provider-neutral AI runtime, Cloudflare and Ollama adapters, streaming chunks,
+  and assistant tool projection.
+- [`coffee/auth`](./coffee/auth): Better Auth runtime setup and delegated Agent
+  Auth capability execution.
 
 ## Layer Placement
 
-Domain and application Layers stay in `packages/coffee/core` when they assemble
-pure application services from ports. External implementation Layers stay with
-their owning External package, such as `packages/coffee/external/sqlite`.
+Domain and application Layers stay in [`coffee/core`](./coffee/core) when they
+assemble pure application services from ports. External implementation Layers
+stay with their owning External package, such as
+[`coffee/external/sqlite`](./coffee/external/sqlite).
 
 Presentation packages may export route, tool, server, or handler Layers. They
-do not choose the concrete database or runtime implementation. `apps/backend`
-is the shell that provides concrete Layers, decodes deployment-specific runtime
-bindings, and composes Cloudflare or Bun entrypoints.
+do not choose the concrete database or runtime implementation.
+[`apps/backend`](../apps/backend) is the shell that provides concrete Layers,
+decodes deployment-specific runtime bindings, and composes Cloudflare or Bun
+entrypoints.

--- a/packages/backend-host/README.md
+++ b/packages/backend-host/README.md
@@ -1,0 +1,33 @@
+# Backend Host
+
+`@effect-coffee-shop/backend-host` provides runtime-agnostic Fetch host utilities.
+
+It is not a Coffee business package. It owns the reusable host plumbing needed by Bun, Cloudflare,
+AWS, and tests: mount dispatch, request logging, observability, JSON helpers, request-scoped
+services, and the MCP HTTP JSON-RPC id compatibility shim.
+
+## Directory Map
+
+- `src/fetch-host.ts` routes Fetch requests to matching mounts and records request telemetry.
+- `src/mount.ts` defines mount contracts and request path helpers.
+- `src/request-services.ts` creates the base request service context supplied to web handlers.
+- `src/logging.ts` writes structured request and actor logs.
+- `src/observability.ts` wires console logging, runtime metrics, and optional OTLP export.
+- `src/json.ts` contains shared JSON formatting helpers.
+- `src/http-jsonrpc-ids.ts` adapts MCP HTTP JSON-RPC ids across host boundaries.
+
+## Boundary Rule
+
+This package may know about generic Fetch requests and shared host concerns. It should not choose a
+Coffee persistence layer, parse deployment-specific bindings, or define Coffee domain/application
+behavior.
+
+## Commands
+
+```bash
+bun run --cwd packages/backend-host typecheck
+bun run --cwd packages/backend-host lint
+bun run --cwd packages/backend-host lint:custom
+bun run --cwd packages/backend-host fmt:check
+bun run --cwd packages/backend-host test
+```

--- a/packages/backend-host/README.md
+++ b/packages/backend-host/README.md
@@ -8,19 +8,23 @@ services, and the MCP HTTP JSON-RPC id compatibility shim.
 
 ## Directory Map
 
-- `src/fetch-host.ts` routes Fetch requests to matching mounts and records request telemetry.
-- `src/mount.ts` defines mount contracts and request path helpers.
-- `src/request-services.ts` creates the base request service context supplied to web handlers.
-- `src/logging.ts` writes structured request and actor logs.
-- `src/observability.ts` wires console logging, runtime metrics, and optional OTLP export.
-- `src/json.ts` contains shared JSON formatting helpers.
-- `src/http-jsonrpc-ids.ts` adapts MCP HTTP JSON-RPC ids across host boundaries.
+- [`src/fetch-host.ts`](./src/fetch-host.ts) routes Fetch requests to matching mounts and records
+  request telemetry.
+- [`src/mount.ts`](./src/mount.ts) defines mount contracts and request path helpers.
+- [`src/request-services.ts`](./src/request-services.ts) creates the base request service context
+  supplied to web handlers.
+- [`src/logging.ts`](./src/logging.ts) writes structured request and actor logs.
+- [`src/observability.ts`](./src/observability.ts) wires console logging, runtime metrics, and
+  optional OTLP export.
+- [`src/json.ts`](./src/json.ts) contains shared JSON formatting helpers.
+- [`src/http-jsonrpc-ids.ts`](./src/http-jsonrpc-ids.ts) adapts MCP HTTP JSON-RPC ids across host
+  boundaries.
 
 ## Boundary Rule
 
 This package may know about generic Fetch requests and shared host concerns. It should not choose a
 Coffee persistence layer, parse deployment-specific bindings, or define Coffee domain/application
-behavior.
+behavior. Runtime composition belongs in [`apps/backend`](../../apps/backend).
 
 ## Commands
 

--- a/packages/backend-host/src/index.ts
+++ b/packages/backend-host/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for backend host request, logging, and observability helpers.
+ *
+ * @module
+ */
 export * from "./fetch-host.ts";
 export * from "./http-jsonrpc-ids.ts";
 export * from "./json.ts";

--- a/packages/coffee/actions/README.md
+++ b/packages/coffee/actions/README.md
@@ -1,14 +1,21 @@
 # Coffee Actions
 
-`@effect-coffee-shop/coffee-actions` is the neutral Coffee capability contract package.
+`@effect-coffee-shop/coffee-actions` is the neutral Coffee capability adapter package.
 
 ## What Is An Action?
 
-An action is a named Coffee application capability with a stable input schema, result schema,
-description, and execution path. It is not an MCP-specific concept. MCP, the assistant, and Agent
-Auth all adapt these same neutral actions into their own protocols, but the canonical action
-contract lives here so those presentation layers do not each invent their own version of `list_menu`,
-`place_order`, or `checkout_cart`.
+An action is a presentation-safe handle for a Coffee application use case. The application layer in
+`coffee-core` remains the source of truth for domain types, business rules, authorization, and
+Effect-based use case functions. This package does not add another business layer.
+
+What it adds is a stable adapter contract for surfaces that cannot directly expose
+`CoffeeOrderApp` methods: action names, descriptions, boundary schemas, JSON input metadata,
+presentation-neutral result formatting, and dispatch from an action name to the underlying
+application use case.
+
+That keeps MCP, the assistant, and Agent Auth from each inventing their own version of `list_menu`,
+`place_order`, or `checkout_cart`. They all adapt this same neutral action catalog into their own
+protocols, while the actual behavior stays in `coffee-core/application`.
 
 It sits at the application/presentation boundary:
 

--- a/packages/coffee/actions/README.md
+++ b/packages/coffee/actions/README.md
@@ -2,6 +2,14 @@
 
 `@effect-coffee-shop/coffee-actions` is the neutral Coffee capability contract package.
 
+## What Is An Action?
+
+An action is a named Coffee application capability with a stable input schema, result schema,
+description, and execution path. It is not an MCP-specific concept. MCP, the assistant, and Agent
+Auth all adapt these same neutral actions into their own protocols, but the canonical action
+contract lives here so those presentation layers do not each invent their own version of `list_menu`,
+`place_order`, or `checkout_cart`.
+
 It sits at the application/presentation boundary:
 
 - It depends inward on `coffee-core` domain and application contracts.

--- a/packages/coffee/actions/README.md
+++ b/packages/coffee/actions/README.md
@@ -2,11 +2,15 @@
 
 `@effect-coffee-shop/coffee-actions` is the neutral Coffee capability adapter package.
 
-## What Is An Action?
+## FAQ
+
+### What Is A Coffee Action?
 
 An action is a presentation-safe handle for a Coffee application use case. The application layer in
 `coffee-core` remains the source of truth for domain types, business rules, authorization, and
 Effect-based use case functions. This package does not add another business layer.
+
+### Why Does This Package Exist If `coffee-core/application` Already Has Use Cases?
 
 What it adds is a stable adapter contract for surfaces that cannot directly expose
 `CoffeeOrderApp` methods: action names, descriptions, boundary schemas, JSON input metadata,
@@ -17,13 +21,42 @@ That keeps MCP, the assistant, and Agent Auth from each inventing their own vers
 `place_order`, or `checkout_cart`. They all adapt this same neutral action catalog into their own
 protocols, while the actual behavior stays in `coffee-core/application`.
 
+### Is This An MCP Package?
+
+No. MCP is one consumer of these action contracts, but this package does not define MCP resources,
+prompts, servers, transports, or SDK-specific tool wiring. MCP-specific adaptation belongs in
+`packages/coffee/presentation/mcp`.
+
+### What Belongs Here?
+
 It sits at the application/presentation boundary:
 
 - It depends inward on `coffee-core` domain and application contracts.
-- It defines shared action names, descriptions, schemas, JSON input metadata, execution helpers, and presentation-neutral formatting.
-- It does not depend on HTTP, MCP, assistant runtimes, Better Auth, Cloudflare, Bun, Node, or external adapter packages.
+- It defines shared action names, descriptions, schemas, JSON input metadata, execution helpers, and
+  presentation-neutral formatting.
+- It does not depend on HTTP, MCP, assistant runtimes, Better Auth, Cloudflare, Bun, Node, or
+  external adapter packages.
 
-Presentation packages adapt these neutral actions into their own transport or runtime format. For example, MCP turns them into Effect MCP tools, the assistant turns them into provider-neutral AI tools, and auth turns them into Agent Auth capabilities.
+Presentation packages adapt these neutral actions into their own transport or runtime format. For
+example, MCP turns them into Effect MCP tools, the assistant turns them into provider-neutral AI
+tools, and auth turns them into Agent Auth capabilities.
+
+### What Does Not Belong Here?
+
+Runtime SDK types, transport concerns, authentication session handling, model-provider details, HTTP
+route definitions, MCP resources, and UI display state belong in the package that owns that surface.
+
+### When Should I Add A New Action?
+
+Add an action when an existing Coffee application use case needs a stable external capability shape
+shared by more than one presentation or capability surface. If only one surface needs a private
+helper, keep that helper in the surface package.
+
+### When Should I Change `coffee-core` Instead?
+
+Change `coffee-core` when the business behavior, domain model, authorization rule, persistence port,
+or Effect use case contract changes. Then update this package only to expose the new or changed
+application behavior to external adapters.
 
 ## Directory Map
 
@@ -35,4 +68,5 @@ Presentation packages adapt these neutral actions into their own transport or ru
 
 ## Boundary Rule
 
-If a type comes from a delivery/runtime SDK, it belongs in the consuming presentation or auth package, not here.
+If a type comes from a delivery/runtime SDK, it belongs in the consuming presentation or auth package,
+not here.

--- a/packages/coffee/actions/README.md
+++ b/packages/coffee/actions/README.md
@@ -7,39 +7,42 @@
 ### What Is A Coffee Action?
 
 An action is a presentation-safe handle for a Coffee application use case. The application layer in
-`coffee-core` remains the source of truth for domain types, business rules, authorization, and
-Effect-based use case functions. This package does not add another business layer.
+[`coffee-core`](../core) remains the source of truth for domain types, business rules,
+authorization, and Effect-based use case functions. This package does not add another business
+layer.
 
 ### Why Does This Package Exist If `coffee-core/application` Already Has Use Cases?
 
 What it adds is a stable adapter contract for surfaces that cannot directly expose
-`CoffeeOrderApp` methods: action names, descriptions, boundary schemas, JSON input metadata,
-presentation-neutral result formatting, and dispatch from an action name to the underlying
-application use case.
+[`CoffeeOrderApp`](../core/src/application/CoffeeOrderApp.ts) methods: action names, descriptions,
+boundary schemas, JSON input metadata, presentation-neutral result formatting, and dispatch from an
+action name to the underlying application use case.
 
 That keeps MCP, the assistant, and Agent Auth from each inventing their own version of `list_menu`,
 `place_order`, or `checkout_cart`. They all adapt this same neutral action catalog into their own
-protocols, while the actual behavior stays in `coffee-core/application`.
+protocols, while the actual behavior stays in
+[`coffee-core/application`](../core/src/application).
 
 ### Is This An MCP Package?
 
 No. MCP is one consumer of these action contracts, but this package does not define MCP resources,
 prompts, servers, transports, or SDK-specific tool wiring. MCP-specific adaptation belongs in
-`packages/coffee/presentation/mcp`.
+[`packages/coffee/presentation/mcp`](../presentation/mcp).
 
 ### What Belongs Here?
 
 It sits at the application/presentation boundary:
 
-- It depends inward on `coffee-core` domain and application contracts.
+- It depends inward on [`coffee-core`](../core) domain and application contracts.
 - It defines shared action names, descriptions, schemas, JSON input metadata, execution helpers, and
   presentation-neutral formatting.
 - It does not depend on HTTP, MCP, assistant runtimes, Better Auth, Cloudflare, Bun, Node, or
   external adapter packages.
 
 Presentation packages adapt these neutral actions into their own transport or runtime format. For
-example, MCP turns them into Effect MCP tools, the assistant turns them into provider-neutral AI
-tools, and auth turns them into Agent Auth capabilities.
+example, [`coffee-mcp`](../presentation/mcp) turns them into Effect MCP tools,
+[`coffee-assistant`](../assistant) turns them into provider-neutral AI tools, and
+[`coffee-auth`](../auth) turns them into Agent Auth capabilities.
 
 ### What Does Not Belong Here?
 
@@ -54,17 +57,18 @@ helper, keep that helper in the surface package.
 
 ### When Should I Change `coffee-core` Instead?
 
-Change `coffee-core` when the business behavior, domain model, authorization rule, persistence port,
-or Effect use case contract changes. Then update this package only to expose the new or changed
-application behavior to external adapters.
+Change [`coffee-core`](../core) when the business behavior, domain model, authorization rule,
+persistence port, or Effect use case contract changes. Then update this package only to expose the
+new or changed application behavior to external adapters.
 
 ## Directory Map
 
-- `src/specs.ts` defines canonical Coffee action specs.
-- `src/schemas.ts` defines shared Effect schemas and decoders.
-- `src/json-schema.ts` defines runtime-neutral JSON object schemas for tool/capability adapters.
-- `src/execute.ts` maps action names to `CoffeeOrderApp` use cases.
-- `src/format.ts` contains shared text formatting for tool/capability results.
+- [`src/specs.ts`](./src/specs.ts) defines canonical Coffee action specs.
+- [`src/schemas.ts`](./src/schemas.ts) defines shared Effect schemas and decoders.
+- [`src/json-schema.ts`](./src/json-schema.ts) defines runtime-neutral JSON object schemas for
+  tool/capability adapters.
+- [`src/execute.ts`](./src/execute.ts) maps action names to `CoffeeOrderApp` use cases.
+- [`src/format.ts`](./src/format.ts) contains shared text formatting for tool/capability results.
 
 ## Boundary Rule
 

--- a/packages/coffee/actions/src/execute.ts
+++ b/packages/coffee/actions/src/execute.ts
@@ -1,3 +1,8 @@
+/**
+ * Executes named Coffee actions against the application service.
+ *
+ * @module
+ */
 import type * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";

--- a/packages/coffee/actions/src/index.ts
+++ b/packages/coffee/actions/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for typed Coffee action execution and tool metadata.
+ *
+ * @module
+ */
 export * from "./execute.ts";
 export * from "./format.ts";
 export * from "./json-schema.ts";

--- a/packages/coffee/actions/src/json-schema.ts
+++ b/packages/coffee/actions/src/json-schema.ts
@@ -1,3 +1,8 @@
+/**
+ * Converts Coffee action schemas into JSON Schema metadata for tools.
+ *
+ * @module
+ */
 export type CoffeeActionJsonSchema = Readonly<{
   properties: Readonly<
     Record<

--- a/packages/coffee/actions/src/schemas.ts
+++ b/packages/coffee/actions/src/schemas.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines action-layer input and error schemas shared by tool surfaces.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 import {
   DrinkNotFoundError,

--- a/packages/coffee/actions/src/specs.ts
+++ b/packages/coffee/actions/src/specs.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines the catalog of Coffee actions and their parameter/result schemas.
+ *
+ * @module
+ */
 import {
   CartItemIdRequestSchema,
   CartViewSchema,

--- a/packages/coffee/actions/src/toolkit.ts
+++ b/packages/coffee/actions/src/toolkit.ts
@@ -1,3 +1,8 @@
+/**
+ * Builds Effect AI toolkit definitions for Coffee actions.
+ *
+ * @module
+ */
 import * as Tool from "effect/unstable/ai/Tool";
 import * as Toolkit from "effect/unstable/ai/Toolkit";
 import { coffeeActionSpecs } from "./specs.ts";

--- a/packages/coffee/assistant/README.md
+++ b/packages/coffee/assistant/README.md
@@ -2,25 +2,38 @@
 
 `@effect-coffee-shop/coffee-assistant` is a Coffee presentation adapter for AI chat.
 
-It owns assistant request handling, message conversion, streaming chunks, tool execution, provider-neutral model orchestration, provider adapter wiring, and assistant observability. It depends inward on `coffee-actions` and `coffee-core/application`, but it does not define canonical Coffee business rules or action contracts.
+It owns assistant request handling, message conversion, streaming chunks, tool execution,
+provider-neutral model orchestration, provider adapter wiring, and assistant observability. It
+depends inward on [`coffee-actions`](../actions) and
+[`coffee-core/application`](../core/src/application), but it does not define canonical Coffee
+business rules or action contracts.
 
 ## Directory Map
 
-- `src/handler.ts` handles assistant HTTP requests and streams responses.
-- `src/runtime.ts` runs the assistant conversation against the `AssistantModelRunner` service.
-- `src/model.ts` defines Beanline's provider-neutral assistant model, model-runner service, message, tool, and tool-call contracts.
-- `src/messages.ts` decodes incoming assistant request messages.
-- `src/chunks.ts` defines streamed assistant response chunks.
-- `src/observability.ts` logs assistant run and tool activity.
-- `src/workers-ai-runtime.ts` adapts the neutral model runner to Cloudflare Workers AI.
-- `src/workers-ai-rest.ts` calls Workers AI over REST for local Bun execution.
-- `src/workers-ai-format.ts` converts assistant state to Workers AI request/response shapes.
-- `src/ollama-runtime.ts` adapts the neutral model runner to Ollama's local chat API.
-- `src/tools/definitions.ts` adapts neutral Coffee actions into executable assistant tools.
-- `src/tools/parameters.ts` adapts neutral action JSON schemas into assistant tool parameter shapes.
+- [`src/handler.ts`](./src/handler.ts) handles assistant HTTP requests and streams responses.
+- [`src/runtime.ts`](./src/runtime.ts) runs the assistant conversation against the
+  `AssistantModelRunner` service.
+- [`src/model.ts`](./src/model.ts) defines Beanline's provider-neutral assistant model,
+  model-runner service, message, tool, and tool-call contracts.
+- [`src/messages.ts`](./src/messages.ts) decodes incoming assistant request messages.
+- [`src/chunks.ts`](./src/chunks.ts) defines streamed assistant response chunks.
+- [`src/observability.ts`](./src/observability.ts) logs assistant run and tool activity.
+- [`src/workers-ai-runtime.ts`](./src/workers-ai-runtime.ts) adapts the neutral model runner to
+  Cloudflare Workers AI.
+- [`src/workers-ai-rest.ts`](./src/workers-ai-rest.ts) calls Workers AI over REST for local Bun
+  execution.
+- [`src/workers-ai-format.ts`](./src/workers-ai-format.ts) converts assistant state to Workers AI
+  request/response shapes.
+- [`src/ollama-runtime.ts`](./src/ollama-runtime.ts) adapts the neutral model runner to Ollama's
+  local chat API.
+- [`src/tools/definitions.ts`](./src/tools/definitions.ts) adapts neutral Coffee actions into
+  executable assistant tools.
+- [`src/tools/parameters.ts`](./src/tools/parameters.ts) adapts neutral action JSON schemas into
+  assistant tool parameter shapes.
 
 ## Boundary Rule
 
-Assistant-specific SDK types and tool formatting stay in provider adapter modules. Shared Coffee action names, schemas, and execution semantics stay in `coffee-actions`.
+Assistant-specific SDK types and tool formatting stay in provider adapter modules. Shared Coffee
+action names, schemas, and execution semantics stay in [`coffee-actions`](../actions).
 
 Provider selection belongs at composition roots. The assistant runtime consumes `AssistantModelRunner` from Effect context, so replacing Workers AI, Ollama, or another model provider should be done by providing a different runner `Layer` rather than changing the conversation loop.

--- a/packages/coffee/auth/README.md
+++ b/packages/coffee/auth/README.md
@@ -2,14 +2,22 @@
 
 `@effect-coffee-shop/coffee-auth` is a Coffee security and integration adapter package.
 
-It is intentionally cross-cutting: Better Auth handles identity/session concerns, Agent Auth exposes delegated Coffee capabilities, and actor resolution feeds authenticated identity into the application layer. The package depends inward on `coffee-actions` and `coffee-core/application`, while Cloudflare-specific Better Auth wiring is isolated under `src/better-auth`.
+It is intentionally cross-cutting: Better Auth handles identity/session concerns, Agent Auth exposes
+delegated Coffee capabilities, and actor resolution feeds authenticated identity into the application
+layer. The package depends inward on [`coffee-actions`](../actions) and
+[`coffee-core/application`](../core/src/application), while Cloudflare-specific Better Auth wiring is
+isolated under [`src/better-auth`](./src/better-auth).
 
 ## Directory Map
 
-- `src/agent/capabilities.ts` adapts neutral Coffee action specs into Agent Auth capability metadata.
-- `src/agent/options.ts` wires Agent Auth execution to `CoffeeOrderApp` with the signed-in customer actor.
-- `src/better-auth/cloudflare.ts` configures Better Auth for the current Cloudflare/D1 runtime.
-- `src/better-auth/users.ts` owns passkey-first user registration helpers.
+- [`src/agent/capabilities.ts`](./src/agent/capabilities.ts) adapts neutral Coffee action specs into
+  Agent Auth capability metadata.
+- [`src/agent/options.ts`](./src/agent/options.ts) wires Agent Auth execution to `CoffeeOrderApp`
+  with the signed-in customer actor.
+- [`src/better-auth/cloudflare.ts`](./src/better-auth/cloudflare.ts) configures Better Auth for the
+  current Cloudflare/D1 runtime.
+- [`src/better-auth/users.ts`](./src/better-auth/users.ts) owns passkey-first user registration
+  helpers.
 
 ## Boundary Rule
 

--- a/packages/coffee/auth/src/index.ts
+++ b/packages/coffee/auth/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for Coffee authentication capabilities and Better Auth adapters.
+ *
+ * @module
+ */
 export * from "./agent/capabilities.ts";
 export * from "./agent/options.ts";
 export * from "./better-auth/cloudflare.ts";

--- a/packages/coffee/core/README.md
+++ b/packages/coffee/core/README.md
@@ -1,0 +1,48 @@
+# Coffee Core
+
+`@effect-coffee-shop/coffee-core` is the Coffee bounded-context core.
+
+It owns the domain model, application use cases, application service tags, ports, errors, actor
+model, observability names, and repository contract helpers. It does not own transport protocols,
+runtime SDKs, database clients, assistant providers, or deployment wiring.
+
+## Architecture
+
+- `src/domain`: pure Coffee concepts such as menu items, money, orders, carts, checkout sessions,
+  and domain errors.
+- `src/application/use-cases`: Effect use cases that enforce business rules and actor access.
+- `src/application/ports`: persistence and id-generator ports required by use cases.
+- `src/application/CoffeeOrderApp.ts`: service facade that wires use cases behind one application
+  service.
+- `src/application/CurrentActor.ts`: request actor model and authorization errors.
+- `src/application/contracts.ts`: boundary schemas and view models shared by adapters.
+- `src/application/testing`: reusable repository contract tests for external adapters.
+
+## FAQ
+
+### What Belongs In Core?
+
+Business behavior that should be true regardless of HTTP, MCP, CLI, assistant, database, or runtime.
+If changing code here changes what Coffee orders mean or how Coffee workflows behave, it likely
+belongs in core.
+
+### What Does Not Belong In Core?
+
+HTTP routes, MCP resources, assistant prompts, Agent Auth metadata, Better Auth setup, database
+client code, Cloudflare bindings, Bun servers, and AWS Lambda handlers belong outside core.
+
+### Where Do External Inputs Get Decoded?
+
+Decode external input at the boundary with Effect schemas. Core may define schemas and typed
+contracts, but presentation and runtime packages decide how HTTP payloads, MCP arguments, auth
+sessions, and environment bindings enter the system.
+
+## Commands
+
+```bash
+bun run --cwd packages/coffee/core typecheck
+bun run --cwd packages/coffee/core lint
+bun run --cwd packages/coffee/core lint:custom
+bun run --cwd packages/coffee/core fmt:check
+bun run --cwd packages/coffee/core test
+```

--- a/packages/coffee/core/README.md
+++ b/packages/coffee/core/README.md
@@ -8,15 +8,20 @@ runtime SDKs, database clients, assistant providers, or deployment wiring.
 
 ## Architecture
 
-- `src/domain`: pure Coffee concepts such as menu items, money, orders, carts, checkout sessions,
-  and domain errors.
-- `src/application/use-cases`: Effect use cases that enforce business rules and actor access.
-- `src/application/ports`: persistence and id-generator ports required by use cases.
-- `src/application/CoffeeOrderApp.ts`: service facade that wires use cases behind one application
-  service.
-- `src/application/CurrentActor.ts`: request actor model and authorization errors.
-- `src/application/contracts.ts`: boundary schemas and view models shared by adapters.
-- `src/application/testing`: reusable repository contract tests for external adapters.
+- [`src/domain`](./src/domain): pure Coffee concepts such as menu items, money, orders, carts,
+  checkout sessions, and domain errors.
+- [`src/application/use-cases`](./src/application/use-cases): Effect use cases that enforce business
+  rules and actor access.
+- [`src/application/ports`](./src/application/ports): persistence and id-generator ports required by
+  use cases.
+- [`src/application/CoffeeOrderApp.ts`](./src/application/CoffeeOrderApp.ts): service facade that
+  wires use cases behind one application service.
+- [`src/application/CurrentActor.ts`](./src/application/CurrentActor.ts): request actor model and
+  authorization errors.
+- [`src/application/contracts.ts`](./src/application/contracts.ts): boundary schemas and view models
+  shared by adapters.
+- [`src/application/testing`](./src/application/testing): reusable repository contract tests for
+  external adapters.
 
 ## FAQ
 
@@ -29,7 +34,9 @@ belongs in core.
 ### What Does Not Belong In Core?
 
 HTTP routes, MCP resources, assistant prompts, Agent Auth metadata, Better Auth setup, database
-client code, Cloudflare bindings, Bun servers, and AWS Lambda handlers belong outside core.
+client code, Cloudflare bindings, Bun servers, and AWS Lambda handlers belong outside core. See the
+[`presentation`](../presentation), [`assistant`](../assistant), [`auth`](../auth), and
+[`external`](../external) package groups for those concerns.
 
 ### Where Do External Inputs Get Decoded?
 

--- a/packages/coffee/core/src/application/CoffeeOrderApp.ts
+++ b/packages/coffee/core/src/application/CoffeeOrderApp.ts
@@ -1,3 +1,8 @@
+/**
+ * Wires Coffee use cases into the application service consumed by adapters.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Context from "effect/Context";

--- a/packages/coffee/core/src/application/CurrentActor.ts
+++ b/packages/coffee/core/src/application/CurrentActor.ts
@@ -1,3 +1,8 @@
+/**
+ * Models the actor currently authorized to run Coffee application workflows.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as Context from "effect/Context";

--- a/packages/coffee/core/src/application/contracts.ts
+++ b/packages/coffee/core/src/application/contracts.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines boundary schemas and view models for Coffee application use cases.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as Schema from "effect/Schema";
 import * as SchemaTransformation from "effect/SchemaTransformation";

--- a/packages/coffee/core/src/application/errors.ts
+++ b/packages/coffee/core/src/application/errors.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines application error conversion and reporting helpers.
+ *
+ * @module
+ */
 import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";

--- a/packages/coffee/core/src/application/observability.ts
+++ b/packages/coffee/core/src/application/observability.ts
@@ -1,3 +1,8 @@
+/**
+ * Declares Coffee application observability spans and metric helpers.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Metric from "effect/Metric";
 import * as Option from "effect/Option";

--- a/packages/coffee/core/src/application/use-cases/cart.ts
+++ b/packages/coffee/core/src/application/use-cases/cart.ts
@@ -1,3 +1,8 @@
+/**
+ * Implements actor-owned cart mutation, pricing, and checkout preparation flows.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";

--- a/packages/coffee/core/src/application/use-cases/changeOrderStatus.ts
+++ b/packages/coffee/core/src/application/use-cases/changeOrderStatus.ts
@@ -1,3 +1,8 @@
+/**
+ * Implements staff order status transitions for the Coffee queue.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import {

--- a/packages/coffee/core/src/application/use-cases/checkoutSession.ts
+++ b/packages/coffee/core/src/application/use-cases/checkoutSession.ts
@@ -1,3 +1,8 @@
+/**
+ * Reads and expires checkout sessions awaiting actor confirmation.
+ *
+ * @module
+ */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";

--- a/packages/coffee/core/src/application/use-cases/getItemOptions.ts
+++ b/packages/coffee/core/src/application/use-cases/getItemOptions.ts
@@ -1,3 +1,8 @@
+/**
+ * Resolves valid customization options for a selected menu item.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";

--- a/packages/coffee/core/src/application/use-cases/getOrder.ts
+++ b/packages/coffee/core/src/application/use-cases/getOrder.ts
@@ -1,3 +1,8 @@
+/**
+ * Fetches one Coffee order with actor-level access control.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import { OrderNotFoundError } from "@effect-coffee-shop/coffee-core/domain/errors";

--- a/packages/coffee/core/src/application/use-cases/index.ts
+++ b/packages/coffee/core/src/application/use-cases/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Re-exports Coffee application use case functions.
+ *
+ * @module
+ */
 export {
   addCartItem,
   checkoutCart,

--- a/packages/coffee/core/src/application/use-cases/listMenu.ts
+++ b/packages/coffee/core/src/application/use-cases/listMenu.ts
@@ -1,3 +1,8 @@
+/**
+ * Lists the current Coffee menu through the menu repository port.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import type { Menu } from "@effect-coffee-shop/coffee-core/domain/menu";
 import {

--- a/packages/coffee/core/src/application/use-cases/listOrders.ts
+++ b/packages/coffee/core/src/application/use-cases/listOrders.ts
@@ -1,3 +1,8 @@
+/**
+ * Lists Coffee orders visible to the current actor.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import { InvalidOrderInputError } from "@effect-coffee-shop/coffee-core/domain/errors";
 import { isOrderStatus, type CoffeeOrders } from "@effect-coffee-shop/coffee-core/domain/order";

--- a/packages/coffee/core/src/application/use-cases/orderItems.ts
+++ b/packages/coffee/core/src/application/use-cases/orderItems.ts
@@ -1,3 +1,8 @@
+/**
+ * Validates, defaults, and prices requested Coffee order items.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";

--- a/packages/coffee/core/src/application/use-cases/placeOrder.ts
+++ b/packages/coffee/core/src/application/use-cases/placeOrder.ts
@@ -1,3 +1,8 @@
+/**
+ * Places Coffee orders and performs cart checkout from confirmed sessions.
+ *
+ * @module
+ */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Match from "effect/Match";

--- a/packages/coffee/core/src/application/use-cases/quoteOrder.ts
+++ b/packages/coffee/core/src/application/use-cases/quoteOrder.ts
@@ -1,3 +1,8 @@
+/**
+ * Quotes and validates proposed Coffee orders without persisting them.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import type { DrinkNotFoundError, InvalidOrderInputError } from "../../domain/errors.ts";
 import type { OrderQuote, QuoteOrderRequest } from "../contracts.ts";

--- a/packages/coffee/core/src/domain/cart.ts
+++ b/packages/coffee/core/src/domain/cart.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines cart item identifiers and actor-owned cart state.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 import { DrinkIdSchema, DrinkSizeSchema, MilkSchema, TemperatureSchema } from "./menu.ts";
 import { QuantitySchema, ShotCountSchema } from "./order-primitives.ts";

--- a/packages/coffee/core/src/domain/checkout-session.ts
+++ b/packages/coffee/core/src/domain/checkout-session.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines immutable checkout sessions created before cart confirmation.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 import { MoneySchema } from "./money.ts";
 import { CoffeeOrderItemSchema } from "./order.ts";

--- a/packages/coffee/core/src/domain/errors.ts
+++ b/packages/coffee/core/src/domain/errors.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines domain-level Coffee ordering error types.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 import { OrderIdSchema, OrderStatusSchema } from "./order.ts";
 

--- a/packages/coffee/core/src/domain/menu.ts
+++ b/packages/coffee/core/src/domain/menu.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines the Coffee menu catalog, item options, and lookup helpers.
+ *
+ * @module
+ */
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { MoneySchema, moneyFromCents, scaleMoney, addMoney, type Money } from "./money.ts";

--- a/packages/coffee/core/src/domain/money.ts
+++ b/packages/coffee/core/src/domain/money.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines exact cent-based money values and arithmetic helpers.
+ *
+ * @module
+ */
 import * as Equal from "effect/Equal";
 import * as Hash from "effect/Hash";
 import * as Schema from "effect/Schema";

--- a/packages/coffee/core/src/domain/order-primitives.ts
+++ b/packages/coffee/core/src/domain/order-primitives.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines shared order primitive schemas for quantities and shot counts.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 
 export const CustomerNameSchema = Schema.Trim.check(Schema.isNonEmpty()).pipe(

--- a/packages/coffee/core/src/domain/order.ts
+++ b/packages/coffee/core/src/domain/order.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines Coffee order, order item, status, and transition rules.
+ *
+ * @module
+ */
 import * as Schema from "effect/Schema";
 import { DrinkIdSchema, DrinkSizeSchema, MilkSchema, TemperatureSchema } from "./menu.ts";
 import { MoneySchema } from "./money.ts";

--- a/packages/coffee/core/src/index.ts
+++ b/packages/coffee/core/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for the Coffee domain model and application service contracts.
+ *
+ * @module
+ */
 export * as DomainErrors from "./domain/errors.ts";
 export * as Cart from "./domain/cart.ts";
 export * as CheckoutSession from "./domain/checkout-session.ts";

--- a/packages/coffee/external/drizzle-postgres/README.md
+++ b/packages/coffee/external/drizzle-postgres/README.md
@@ -3,16 +3,18 @@
 `@effect-coffee-shop/coffee-external-drizzle-postgres` provides a
 Postgres-backed implementation of the Coffee application ports.
 
+See [`coffee-core`](../../core) for the ports implemented by this package.
+
 ## Exports
 
 | Name                                    | Description                                         |
 | --------------------------------------- | --------------------------------------------------- |
-| `DrizzlePostgresCoffeeAppLive`          | Complete Postgres Coffee application layer.         |
-| `DrizzlePostgresCoffeeRepositoriesLive` | Combined Drizzle-backed Coffee repositories/cart.   |
-| `DrizzlePostgresSchemaLive`             | Postgres migration and schema setup layer.          |
-| `DrizzlePostgresSchemaReady`            | Schema readiness service tag for Postgres startup.  |
-| `CoffeeDb`                              | Effect service tag for the Drizzle database client. |
-| `PgCoffeeClientLive`                    | Postgres SQL client layer for Coffee storage.       |
+| [`DrizzlePostgresCoffeeAppLive`](./src/live.ts) | Complete Postgres Coffee application layer. |
+| [`DrizzlePostgresCoffeeRepositoriesLive`](./src/live.ts) | Combined Drizzle-backed Coffee repositories/cart. |
+| [`DrizzlePostgresSchemaLive`](./src/live.ts) | Postgres migration and schema setup layer. |
+| [`DrizzlePostgresSchemaReady`](./src/db/schema-ready.ts) | Schema readiness service tag for Postgres startup. |
+| [`CoffeeDb`](./src/db/Db.ts) | Effect service tag for the Drizzle database client. |
+| [`PgCoffeeClientLive`](./src/db/Db.ts) | Postgres SQL client layer for Coffee storage. |
 
 ## Commands
 

--- a/packages/coffee/external/drizzle-postgres/README.md
+++ b/packages/coffee/external/drizzle-postgres/README.md
@@ -7,14 +7,14 @@ See [`coffee-core`](../../core) for the ports implemented by this package.
 
 ## Exports
 
-| Name                                    | Description                                         |
-| --------------------------------------- | --------------------------------------------------- |
-| [`DrizzlePostgresCoffeeAppLive`](./src/live.ts) | Complete Postgres Coffee application layer. |
-| [`DrizzlePostgresCoffeeRepositoriesLive`](./src/live.ts) | Combined Drizzle-backed Coffee repositories/cart. |
-| [`DrizzlePostgresSchemaLive`](./src/live.ts) | Postgres migration and schema setup layer. |
-| [`DrizzlePostgresSchemaReady`](./src/db/schema-ready.ts) | Schema readiness service tag for Postgres startup. |
-| [`CoffeeDb`](./src/db/Db.ts) | Effect service tag for the Drizzle database client. |
-| [`PgCoffeeClientLive`](./src/db/Db.ts) | Postgres SQL client layer for Coffee storage. |
+| Name                                                     | Description                                         |
+| -------------------------------------------------------- | --------------------------------------------------- |
+| [`DrizzlePostgresCoffeeAppLive`](./src/live.ts)          | Complete Postgres Coffee application layer.         |
+| [`DrizzlePostgresCoffeeRepositoriesLive`](./src/live.ts) | Combined Drizzle-backed Coffee repositories/cart.   |
+| [`DrizzlePostgresSchemaLive`](./src/live.ts)             | Postgres migration and schema setup layer.          |
+| [`DrizzlePostgresSchemaReady`](./src/db/schema-ready.ts) | Schema readiness service tag for Postgres startup.  |
+| [`CoffeeDb`](./src/db/Db.ts)                             | Effect service tag for the Drizzle database client. |
+| [`PgCoffeeClientLive`](./src/db/Db.ts)                   | Postgres SQL client layer for Coffee storage.       |
 
 ## Commands
 

--- a/packages/coffee/external/drizzle-postgres/src/db/Db.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/Db.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines the Drizzle/Postgres database service and live client layer.
+ *
+ * @module
+ */
 import { PgClient } from "@effect/sql-pg";
 import * as Config from "effect/Config";
 import * as Context from "effect/Context";

--- a/packages/coffee/external/drizzle-postgres/src/db/auth-schema.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/auth-schema.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines Better Auth tables for the Postgres persistence schema.
+ *
+ * @module
+ */
 import { boolean, index, integer, pgTable, text, timestamp } from "drizzle-orm/pg-core";
 
 const createdAt = () => timestamp("createdAt", { withTimezone: true }).notNull();

--- a/packages/coffee/external/drizzle-postgres/src/db/migrate.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/migrate.ts
@@ -1,3 +1,8 @@
+/**
+ * Runs Drizzle migrations for the Postgres persistence schema.
+ *
+ * @module
+ */
 import * as NodePath from "node:path";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/drizzle-postgres/src/db/models.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/models.ts
@@ -1,3 +1,8 @@
+/**
+ * Maps Postgres rows to Coffee domain models and persistence payloads.
+ *
+ * @module
+ */
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import { createSelectSchema } from "drizzle-orm/effect-schema";

--- a/packages/coffee/external/drizzle-postgres/src/db/persistence.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/persistence.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides Drizzle/Postgres helpers for Coffee persistence operations.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { menuItems } from "@effect-coffee-shop/coffee-core/domain/menu";

--- a/packages/coffee/external/drizzle-postgres/src/db/schema-ready.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/schema-ready.ts
@@ -1,3 +1,8 @@
+/**
+ * Tracks whether the Postgres schema has been migrated for the runtime.
+ *
+ * @module
+ */
 import * as Context from "effect/Context";
 
 export class DrizzlePostgresSchemaReady extends Context.Service<

--- a/packages/coffee/external/drizzle-postgres/src/db/schema.ts
+++ b/packages/coffee/external/drizzle-postgres/src/db/schema.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines Drizzle tables and sequences for Coffee Postgres persistence.
+ *
+ * @module
+ */
 import { index, integer, jsonb, pgSequence, pgTable, primaryKey, text } from "drizzle-orm/pg-core";
 import type { Milk, Temperature } from "@effect-coffee-shop/coffee-core/domain/menu";
 import { authSchema } from "./auth-schema.ts";

--- a/packages/coffee/external/drizzle-postgres/src/index.ts
+++ b/packages/coffee/external/drizzle-postgres/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for the Drizzle/Postgres Coffee persistence adapter.
+ *
+ * @module
+ */
 export { CoffeeDb, PgCoffeeClientLive } from "./db/Db.ts";
 export { DrizzlePostgresSchemaLive } from "./db/migrate.ts";
 export { DrizzlePostgresSchemaReady } from "./db/schema-ready.ts";

--- a/packages/coffee/external/drizzle-postgres/src/live.ts
+++ b/packages/coffee/external/drizzle-postgres/src/live.ts
@@ -1,3 +1,8 @@
+/**
+ * Composes Drizzle/Postgres repositories and schema readiness into one layer.
+ *
+ * @module
+ */
 import * as Layer from "effect/Layer";
 import { CoffeeDb } from "./db/Db.ts";
 import { DrizzlePostgresSchemaLive } from "./db/migrate.ts";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCartItemIdGenerator.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCartItemIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates cart item identifiers from the Postgres backing store.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { cartItemIdFromString } from "@effect-coffee-shop/coffee-core/domain/cart";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCartRepository.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCartRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists actor carts with Drizzle/Postgres.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCheckoutSessionIdGenerator.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCheckoutSessionIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates checkout session identifiers from the Postgres backing store.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCheckoutSessionRepository.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleCheckoutSessionRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists checkout sessions with Drizzle/Postgres.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleMenuRepository.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleMenuRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Reads the static Coffee menu through the Drizzle repository port.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleOrderIdGenerator.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleOrderIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates Coffee order identifiers from the Postgres backing store.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleOrderRepository.ts
+++ b/packages/coffee/external/drizzle-postgres/src/repositories/DrizzleOrderRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists Coffee orders with Drizzle/Postgres.
+ *
+ * @module
+ */
 import * as Arr from "effect/Array";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/in-memory/README.md
+++ b/packages/coffee/external/in-memory/README.md
@@ -11,15 +11,15 @@ See [`coffee-core`](../../core) for the ports implemented by this package.
 
 ## Exports
 
-| Name                              | Description                                      |
-| --------------------------------- | ------------------------------------------------ |
-| [`CoffeeAppLive`](./src/index.ts) | Complete in-memory Coffee application layer. |
-| [`InMemoryCoffeeRepositoriesLive`](./src/index.ts) | Combined in-memory Coffee repositories. |
-| [`InMemoryCartRepositoryLive`](./src/in-memory/InMemoryCartRepository.ts) | In-memory cart repository implementation. |
+| Name                                                                                | Description                                      |
+| ----------------------------------------------------------------------------------- | ------------------------------------------------ |
+| [`CoffeeAppLive`](./src/index.ts)                                                   | Complete in-memory Coffee application layer.     |
+| [`InMemoryCoffeeRepositoriesLive`](./src/index.ts)                                  | Combined in-memory Coffee repositories.          |
+| [`InMemoryCartRepositoryLive`](./src/in-memory/InMemoryCartRepository.ts)           | In-memory cart repository implementation.        |
 | [`InMemoryCartItemIdGeneratorLive`](./src/in-memory/InMemoryCartItemIdGenerator.ts) | In-memory cart item ID generator implementation. |
-| [`InMemoryMenuRepositoryLive`](./src/in-memory/InMemoryMenuRepository.ts) | In-memory menu repository implementation. |
-| [`InMemoryOrderRepositoryLive`](./src/in-memory/InMemoryOrderRepository.ts) | In-memory order repository implementation. |
-| [`InMemoryOrderIdGeneratorLive`](./src/in-memory/InMemoryOrderIdGenerator.ts) | In-memory order ID generator implementation. |
+| [`InMemoryMenuRepositoryLive`](./src/in-memory/InMemoryMenuRepository.ts)           | In-memory menu repository implementation.        |
+| [`InMemoryOrderRepositoryLive`](./src/in-memory/InMemoryOrderRepository.ts)         | In-memory order repository implementation.       |
+| [`InMemoryOrderIdGeneratorLive`](./src/in-memory/InMemoryOrderIdGenerator.ts)       | In-memory order ID generator implementation.     |
 
 ## Commands
 

--- a/packages/coffee/external/in-memory/README.md
+++ b/packages/coffee/external/in-memory/README.md
@@ -7,17 +7,19 @@ It is useful for local development, tests, and adapter contracts that do not
 need durable storage. The composition root chooses whether to use this package
 or a durable external layer.
 
+See [`coffee-core`](../../core) for the ports implemented by this package.
+
 ## Exports
 
 | Name                              | Description                                      |
 | --------------------------------- | ------------------------------------------------ |
-| `CoffeeAppLive`                   | Complete in-memory Coffee application layer.     |
-| `InMemoryCoffeeRepositoriesLive`  | Combined in-memory Coffee repositories.          |
-| `InMemoryCartRepositoryLive`      | In-memory cart repository implementation.        |
-| `InMemoryCartItemIdGeneratorLive` | In-memory cart item ID generator implementation. |
-| `InMemoryMenuRepositoryLive`      | In-memory menu repository implementation.        |
-| `InMemoryOrderRepositoryLive`     | In-memory order repository implementation.       |
-| `InMemoryOrderIdGeneratorLive`    | In-memory order ID generator implementation.     |
+| [`CoffeeAppLive`](./src/index.ts) | Complete in-memory Coffee application layer. |
+| [`InMemoryCoffeeRepositoriesLive`](./src/index.ts) | Combined in-memory Coffee repositories. |
+| [`InMemoryCartRepositoryLive`](./src/in-memory/InMemoryCartRepository.ts) | In-memory cart repository implementation. |
+| [`InMemoryCartItemIdGeneratorLive`](./src/in-memory/InMemoryCartItemIdGenerator.ts) | In-memory cart item ID generator implementation. |
+| [`InMemoryMenuRepositoryLive`](./src/in-memory/InMemoryMenuRepository.ts) | In-memory menu repository implementation. |
+| [`InMemoryOrderRepositoryLive`](./src/in-memory/InMemoryOrderRepository.ts) | In-memory order repository implementation. |
+| [`InMemoryOrderIdGeneratorLive`](./src/in-memory/InMemoryOrderIdGenerator.ts) | In-memory order ID generator implementation. |
 
 ## Commands
 

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCartItemIdGenerator.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCartItemIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides deterministic in-memory cart item identifiers.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { cartItemIdFromString } from "@effect-coffee-shop/coffee-core/domain/cart";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Stores actor carts in memory for local and test runtimes.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionIdGenerator.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides deterministic in-memory checkout session identifiers.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { checkoutSessionIdFromString } from "@effect-coffee-shop/coffee-core/domain/checkout-session";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Stores checkout sessions in memory for local and test runtimes.
+ *
+ * @module
+ */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryMenuRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryMenuRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Serves the built-in Coffee menu from memory.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderIdGenerator.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides deterministic in-memory order identifiers.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { orderIdFromString } from "@effect-coffee-shop/coffee-core/domain/order";

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Stores Coffee orders in memory for local and test runtimes.
+ *
+ * @module
+ */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/external/in-memory/src/index.ts
+++ b/packages/coffee/external/in-memory/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports and layers for in-memory Coffee repositories.
+ *
+ * @module
+ */
 import * as Layer from "effect/Layer";
 import { InMemoryCartItemIdGeneratorLive } from "./in-memory/InMemoryCartItemIdGenerator.ts";
 import { InMemoryCartRepositoryLive } from "./in-memory/InMemoryCartRepository.ts";

--- a/packages/coffee/external/sqlite/README.md
+++ b/packages/coffee/external/sqlite/README.md
@@ -11,12 +11,12 @@ See [`coffee-core`](../../core) for the ports implemented by this package.
 
 ## Exports
 
-| Name                                | Description                                        |
-| ----------------------------------- | -------------------------------------------------- |
-| [`SqlCoffeeAppLive`](./src/bun/live.ts) | Bun SQLite Coffee application layer. |
-| [`SqlCoffeeRepositoriesLive`](./src/sql/live.ts) | Shared SQL-backed Coffee repositories and cart. |
-| [`makeCloudflareCoffeeAppLive`](./src/cloudflare/live.ts) | Builds the Cloudflare D1 Coffee application layer. |
-| [`makeCloudflareSqlCoffeeSchemaLive`](./src/cloudflare/live.ts) | Builds the Cloudflare D1 schema readiness layer. |
+| Name                                                            | Description                                        |
+| --------------------------------------------------------------- | -------------------------------------------------- |
+| [`SqlCoffeeAppLive`](./src/bun/live.ts)                         | Bun SQLite Coffee application layer.               |
+| [`SqlCoffeeRepositoriesLive`](./src/sql/live.ts)                | Shared SQL-backed Coffee repositories and cart.    |
+| [`makeCloudflareCoffeeAppLive`](./src/cloudflare/live.ts)       | Builds the Cloudflare D1 Coffee application layer. |
+| [`makeCloudflareSqlCoffeeSchemaLive`](./src/cloudflare/live.ts) | Builds the Cloudflare D1 schema readiness layer.   |
 
 ## Commands
 

--- a/packages/coffee/external/sqlite/README.md
+++ b/packages/coffee/external/sqlite/README.md
@@ -7,14 +7,16 @@ The SQL definitions, generated queries, and migrations live under
 [`src/sql`](./src/sql). Runtime-specific layers adapt Bun SQLite or Cloudflare
 D1 into the shared SQL repository layer.
 
+See [`coffee-core`](../../core) for the ports implemented by this package.
+
 ## Exports
 
 | Name                                | Description                                        |
 | ----------------------------------- | -------------------------------------------------- |
-| `SqlCoffeeAppLive`                  | Bun SQLite Coffee application layer.               |
-| `SqlCoffeeRepositoriesLive`         | Shared SQL-backed Coffee repositories and cart.    |
-| `makeCloudflareCoffeeAppLive`       | Builds the Cloudflare D1 Coffee application layer. |
-| `makeCloudflareSqlCoffeeSchemaLive` | Builds the Cloudflare D1 schema readiness layer.   |
+| [`SqlCoffeeAppLive`](./src/bun/live.ts) | Bun SQLite Coffee application layer. |
+| [`SqlCoffeeRepositoriesLive`](./src/sql/live.ts) | Shared SQL-backed Coffee repositories and cart. |
+| [`makeCloudflareCoffeeAppLive`](./src/cloudflare/live.ts) | Builds the Cloudflare D1 Coffee application layer. |
+| [`makeCloudflareSqlCoffeeSchemaLive`](./src/cloudflare/live.ts) | Builds the Cloudflare D1 schema readiness layer. |
 
 ## Commands
 

--- a/packages/coffee/external/sqlite/src/bun/live.ts
+++ b/packages/coffee/external/sqlite/src/bun/live.ts
@@ -1,3 +1,8 @@
+/**
+ * Builds the SQLite persistence layer for Bun runtimes.
+ *
+ * @module
+ */
 import * as BunServices from "@effect/platform-bun/BunServices";
 import { Database } from "bun:sqlite";
 import * as Effect from "effect/Effect";

--- a/packages/coffee/external/sqlite/src/bun/sqlite.ts
+++ b/packages/coffee/external/sqlite/src/bun/sqlite.ts
@@ -1,3 +1,8 @@
+/**
+ * Configures a Bun SQLite client from runtime configuration.
+ *
+ * @module
+ */
 import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as FileSystem from "effect/FileSystem";

--- a/packages/coffee/external/sqlite/src/cloudflare/live.ts
+++ b/packages/coffee/external/sqlite/src/cloudflare/live.ts
@@ -1,3 +1,8 @@
+/**
+ * Builds the SQLite persistence layer for Cloudflare D1 runtimes.
+ *
+ * @module
+ */
 import type { D1Database } from "@cloudflare/workers-types";
 import { D1Client } from "@effect/sql-d1";
 import * as Effect from "effect/Effect";

--- a/packages/coffee/external/sqlite/src/index.ts
+++ b/packages/coffee/external/sqlite/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for SQLite and D1 Coffee persistence adapters.
+ *
+ * @module
+ */
 export {
   makeCloudflareCoffeeAppLive,
   makeCloudflareSqlCoffeeSchemaLive,

--- a/packages/coffee/external/sqlite/src/sql/CartItemIdGenerator.ts
+++ b/packages/coffee/external/sqlite/src/sql/CartItemIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates cart item identifiers from the SQL backing store.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { cartItemIdFromString } from "@effect-coffee-shop/coffee-core/domain/cart";

--- a/packages/coffee/external/sqlite/src/sql/CheckoutSessionIdGenerator.ts
+++ b/packages/coffee/external/sqlite/src/sql/CheckoutSessionIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates checkout session identifiers from the SQL backing store.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { checkoutSessionIdFromString } from "@effect-coffee-shop/coffee-core/domain/checkout-session";

--- a/packages/coffee/external/sqlite/src/sql/OrderIdGenerator.ts
+++ b/packages/coffee/external/sqlite/src/sql/OrderIdGenerator.ts
@@ -1,3 +1,8 @@
+/**
+ * Allocates Coffee order identifiers from the SQL backing store.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { orderIdFromString } from "@effect-coffee-shop/coffee-core/domain/order";

--- a/packages/coffee/external/sqlite/src/sql/SqlCartRepository.ts
+++ b/packages/coffee/external/sqlite/src/sql/SqlCartRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists actor carts in the shared SQLite schema.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/sqlite/src/sql/SqlCheckoutSessionRepository.ts
+++ b/packages/coffee/external/sqlite/src/sql/SqlCheckoutSessionRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists checkout sessions in the shared SQLite schema.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/sqlite/src/sql/SqlMenuRepository.ts
+++ b/packages/coffee/external/sqlite/src/sql/SqlMenuRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Reads the static Coffee menu through the SQL repository port.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/sqlite/src/sql/SqlOrderRepository.ts
+++ b/packages/coffee/external/sqlite/src/sql/SqlOrderRepository.ts
@@ -1,3 +1,8 @@
+/**
+ * Persists Coffee orders in the shared SQLite schema.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/external/sqlite/src/sql/better-auth-schema.ts
+++ b/packages/coffee/external/sqlite/src/sql/better-auth-schema.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines Better Auth tables for SQLite and D1 deployments.
+ *
+ * @module
+ */
 import { agentAuth } from "@better-auth/agent-auth";
 import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";

--- a/packages/coffee/external/sqlite/src/sql/live.ts
+++ b/packages/coffee/external/sqlite/src/sql/live.ts
@@ -1,3 +1,8 @@
+/**
+ * Composes SQLite repositories and schema readiness into one layer.
+ *
+ * @module
+ */
 import * as Layer from "effect/Layer";
 import { SqlCartItemIdGeneratorLive } from "./CartItemIdGenerator.ts";
 import { SqlCheckoutSessionIdGeneratorLive } from "./CheckoutSessionIdGenerator.ts";

--- a/packages/coffee/external/sqlite/src/sql/models.ts
+++ b/packages/coffee/external/sqlite/src/sql/models.ts
@@ -1,3 +1,8 @@
+/**
+ * Maps SQLite rows to Coffee domain models and persistence payloads.
+ *
+ * @module
+ */
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import {

--- a/packages/coffee/external/sqlite/src/sql/persistence.ts
+++ b/packages/coffee/external/sqlite/src/sql/persistence.ts
@@ -1,3 +1,8 @@
+/**
+ * Provides SQL helpers for transactional Coffee persistence operations.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import { menuItems } from "@effect-coffee-shop/coffee-core/domain/menu";

--- a/packages/coffee/external/sqlite/src/sql/schema-ready.ts
+++ b/packages/coffee/external/sqlite/src/sql/schema-ready.ts
@@ -1,3 +1,8 @@
+/**
+ * Tracks whether the SQLite schema has been prepared for the runtime.
+ *
+ * @module
+ */
 import * as Context from "effect/Context";
 
 export class SqlCoffeeSchemaReady extends Context.Service<

--- a/packages/coffee/external/sqlite/src/sql/sqlfu.config.ts
+++ b/packages/coffee/external/sqlite/src/sql/sqlfu.config.ts
@@ -1,3 +1,8 @@
+/**
+ * Configures SQLFu code generation for the SQLite persistence schema.
+ *
+ * @module
+ */
 import { defineConfig } from "sqlfu";
 
 export default defineConfig({

--- a/packages/coffee/presentation/cli/README.md
+++ b/packages/coffee/presentation/cli/README.md
@@ -1,0 +1,34 @@
+# Coffee CLI
+
+`@effect-coffee-shop/coffee-cli` adapts `CoffeeOrderApp` to Effect CLI commands.
+
+The CLI is a presentation surface for local development and operational smoke checks. It formats
+application views as JSON and relies on the composition root to provide the concrete Coffee
+application layer.
+
+## Command Surface
+
+- `coffee menu list`: print the menu.
+- `coffee order create`: place a customer order.
+- `coffee order get`: fetch one order by id.
+- `coffee order list`: list orders, optionally by status.
+- `coffee order cancel`: cancel a pending or brewing order.
+- `coffee barista start`: move an order into brewing.
+- `coffee barista ready`: mark an order ready.
+- `coffee barista pickup`: mark an order picked up.
+
+## Boundary Rule
+
+CLI flags and command formatting belong here. Business rules stay in `coffee-core/application`, and
+runtime persistence choices stay in the backend app that runs the command.
+
+## Commands
+
+```bash
+bun run --cwd apps/backend cli -- --help
+bun run --cwd packages/coffee/presentation/cli typecheck
+bun run --cwd packages/coffee/presentation/cli lint
+bun run --cwd packages/coffee/presentation/cli lint:custom
+bun run --cwd packages/coffee/presentation/cli fmt:check
+bun run --cwd packages/coffee/presentation/cli test
+```

--- a/packages/coffee/presentation/cli/README.md
+++ b/packages/coffee/presentation/cli/README.md
@@ -19,8 +19,9 @@ application layer.
 
 ## Boundary Rule
 
-CLI flags and command formatting belong here. Business rules stay in `coffee-core/application`, and
-runtime persistence choices stay in the backend app that runs the command.
+CLI flags and command formatting belong here. Business rules stay in
+[`coffee-core/application`](../../core/src/application), and runtime persistence choices stay in the
+[`backend app`](../../../../apps/backend) that runs the command.
 
 ## Commands
 

--- a/packages/coffee/presentation/cli/src/index.ts
+++ b/packages/coffee/presentation/cli/src/index.ts
@@ -1,1 +1,6 @@
+/**
+ * Public exports for the Coffee command-line presentation surface.
+ *
+ * @module
+ */
 export * from "./command.ts";

--- a/packages/coffee/presentation/http/README.md
+++ b/packages/coffee/presentation/http/README.md
@@ -8,16 +8,18 @@ or core business behavior.
 
 ## Directory Map
 
-- `src/api.ts` defines health, session, menu, and order HTTP API groups and handlers.
-- `src/web-handler.ts` turns API layers into a Fetch-compatible handler.
-- `src/bun-server.ts` runs the HTTP API through the Bun server adapter.
-- `src/test-support.ts` contains HTTP test helpers.
+- [`src/api.ts`](./src/api.ts) defines health, session, menu, and order HTTP API groups and
+  handlers.
+- [`src/web-handler.ts`](./src/web-handler.ts) turns API layers into a Fetch-compatible handler.
+- [`src/bun-server.ts`](./src/bun-server.ts) runs the HTTP API through the Bun server adapter.
+- [`src/test-support.ts`](./src/test-support.ts) contains HTTP test helpers.
 
 ## Boundary Rule
 
 HTTP paths, HTTP payload decoding, response schemas, and HTTP handler composition belong here.
 Request actor resolution and concrete persistence are provided by runtime shells such as
-`apps/backend`.
+[`apps/backend`](../../../../apps/backend). Business behavior stays in
+[`coffee-core`](../../core).
 
 ## Commands
 

--- a/packages/coffee/presentation/http/README.md
+++ b/packages/coffee/presentation/http/README.md
@@ -1,0 +1,31 @@
+# Coffee HTTP
+
+`@effect-coffee-shop/coffee-http` adapts the Coffee application service to an Effect HTTP API.
+
+It defines HTTP groups, endpoint schemas, handler layers, a Web Fetch handler adapter, and a local
+Bun server adapter. The package owns the HTTP shape, but not database selection, deployment bindings,
+or core business behavior.
+
+## Directory Map
+
+- `src/api.ts` defines health, session, menu, and order HTTP API groups and handlers.
+- `src/web-handler.ts` turns API layers into a Fetch-compatible handler.
+- `src/bun-server.ts` runs the HTTP API through the Bun server adapter.
+- `src/test-support.ts` contains HTTP test helpers.
+
+## Boundary Rule
+
+HTTP paths, HTTP payload decoding, response schemas, and HTTP handler composition belong here.
+Request actor resolution and concrete persistence are provided by runtime shells such as
+`apps/backend`.
+
+## Commands
+
+```bash
+bun run --cwd apps/backend http
+bun run --cwd packages/coffee/presentation/http typecheck
+bun run --cwd packages/coffee/presentation/http lint
+bun run --cwd packages/coffee/presentation/http lint:custom
+bun run --cwd packages/coffee/presentation/http fmt:check
+bun run --cwd packages/coffee/presentation/http test
+```

--- a/packages/coffee/presentation/http/src/api.ts
+++ b/packages/coffee/presentation/http/src/api.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines the Coffee HTTP API groups, endpoints, and server handlers.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Schema from "effect/Schema";

--- a/packages/coffee/presentation/http/src/bun-server.ts
+++ b/packages/coffee/presentation/http/src/bun-server.ts
@@ -1,3 +1,8 @@
+/**
+ * Runs the Coffee HTTP API with the Bun HTTP server adapter.
+ *
+ * @module
+ */
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";

--- a/packages/coffee/presentation/http/src/index.ts
+++ b/packages/coffee/presentation/http/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for the Coffee HTTP API presentation surface.
+ *
+ * @module
+ */
 export * from "./api.ts";
 export * from "./bun-server.ts";
 export * from "./web-handler.ts";

--- a/packages/coffee/presentation/http/src/web-handler.ts
+++ b/packages/coffee/presentation/http/src/web-handler.ts
@@ -1,3 +1,8 @@
+/**
+ * Adapts the Coffee HTTP API into a Web Fetch handler.
+ *
+ * @module
+ */
 import * as Layer from "effect/Layer";
 import * as Context from "effect/Context";
 import * as HttpServer from "effect/unstable/http/HttpServer";

--- a/packages/coffee/presentation/mcp/README.md
+++ b/packages/coffee/presentation/mcp/README.md
@@ -3,8 +3,8 @@
 `@effect-coffee-shop/coffee-mcp` adapts Coffee application capabilities to MCP.
 
 It defines MCP resources, prompts, tools, and server layers for stdio and HTTP transports. It uses
-the neutral action catalog from `coffee-actions` for tools, while MCP-only resources and prompts stay
-in this package.
+the neutral action catalog from [`coffee-actions`](../../actions) for tools, while MCP-only
+resources and prompts stay in this package.
 
 ## FAQ
 
@@ -15,14 +15,15 @@ server layers.
 
 ### How Do Actions Become MCP Tools?
 
-`src/action-tools.ts` adapts `CoffeeActionToolkit` from `coffee-actions` into MCP tools. The action
-names, schemas, and neutral action metadata stay in `coffee-actions`; this package only performs the
-MCP projection.
+[`src/action-tools.ts`](./src/action-tools.ts) adapts `CoffeeActionToolkit` from
+[`coffee-actions`](../../actions) into MCP tools. The action names, schemas, and neutral action
+metadata stay in `coffee-actions`; this package only performs the MCP projection.
 
 ### What Is The Difference Between Resources, Prompts, And Tools?
 
 Resources expose readable Coffee state such as menu or order data. Prompts provide reusable MCP
-prompt templates. Tools perform actions through `CoffeeOrderApp`, such as listing orders or updating
+prompt templates. Tools perform actions through
+[`CoffeeOrderApp`](../../core/src/application/CoffeeOrderApp.ts), such as listing orders or updating
 order status.
 
 ### What Does Not Belong Here?
@@ -32,10 +33,10 @@ mount routing belong in their owning packages.
 
 ## Directory Map
 
-- `src/action-tools.ts` adapts neutral Coffee actions into MCP tools.
-- `src/resources.ts` defines menu and order MCP resources.
-- `src/prompts.ts` defines recommendation and open-order summary prompts.
-- `src/server.ts` composes MCP features into stdio and HTTP server layers.
+- [`src/action-tools.ts`](./src/action-tools.ts) adapts neutral Coffee actions into MCP tools.
+- [`src/resources.ts`](./src/resources.ts) defines menu and order MCP resources.
+- [`src/prompts.ts`](./src/prompts.ts) defines recommendation and open-order summary prompts.
+- [`src/server.ts`](./src/server.ts) composes MCP features into stdio and HTTP server layers.
 
 ## Commands
 

--- a/packages/coffee/presentation/mcp/README.md
+++ b/packages/coffee/presentation/mcp/README.md
@@ -1,0 +1,50 @@
+# Coffee MCP
+
+`@effect-coffee-shop/coffee-mcp` adapts Coffee application capabilities to MCP.
+
+It defines MCP resources, prompts, tools, and server layers for stdio and HTTP transports. It uses
+the neutral action catalog from `coffee-actions` for tools, while MCP-only resources and prompts stay
+in this package.
+
+## FAQ
+
+### What Lives Here?
+
+MCP-specific protocol definitions: resources, prompts, tools, server metadata, and stdio/HTTP MCP
+server layers.
+
+### How Do Actions Become MCP Tools?
+
+`src/action-tools.ts` adapts `CoffeeActionToolkit` from `coffee-actions` into MCP tools. The action
+names, schemas, and neutral action metadata stay in `coffee-actions`; this package only performs the
+MCP projection.
+
+### What Is The Difference Between Resources, Prompts, And Tools?
+
+Resources expose readable Coffee state such as menu or order data. Prompts provide reusable MCP
+prompt templates. Tools perform actions through `CoffeeOrderApp`, such as listing orders or updating
+order status.
+
+### What Does Not Belong Here?
+
+Canonical Coffee action contracts, business rules, database clients, auth session setup, and host
+mount routing belong in their owning packages.
+
+## Directory Map
+
+- `src/action-tools.ts` adapts neutral Coffee actions into MCP tools.
+- `src/resources.ts` defines menu and order MCP resources.
+- `src/prompts.ts` defines recommendation and open-order summary prompts.
+- `src/server.ts` composes MCP features into stdio and HTTP server layers.
+
+## Commands
+
+```bash
+bun run --cwd apps/backend mcp:stdio
+bun run --cwd apps/backend mcp:http
+bun run --cwd packages/coffee/presentation/mcp typecheck
+bun run --cwd packages/coffee/presentation/mcp lint
+bun run --cwd packages/coffee/presentation/mcp lint:custom
+bun run --cwd packages/coffee/presentation/mcp fmt:check
+bun run --cwd packages/coffee/presentation/mcp test
+```

--- a/packages/coffee/presentation/mcp/src/action-tools.ts
+++ b/packages/coffee/presentation/mcp/src/action-tools.ts
@@ -1,3 +1,8 @@
+/**
+ * Exposes Coffee actions as MCP tools.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";

--- a/packages/coffee/presentation/mcp/src/index.ts
+++ b/packages/coffee/presentation/mcp/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Public exports for the Coffee MCP server presentation surface.
+ *
+ * @module
+ */
 export * from "./action-tools.ts";
 export * from "./prompts.ts";
 export * from "./resources.ts";

--- a/packages/coffee/presentation/mcp/src/prompts.ts
+++ b/packages/coffee/presentation/mcp/src/prompts.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines MCP prompts for Coffee recommendations and queue summaries.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import * as McpServer from "effect/unstable/ai/McpServer";

--- a/packages/coffee/presentation/mcp/src/resources.ts
+++ b/packages/coffee/presentation/mcp/src/resources.ts
@@ -1,3 +1,8 @@
+/**
+ * Defines MCP resources for menu and order inspection.
+ *
+ * @module
+ */
 import * as Effect from "effect/Effect";
 import * as McpSchema from "effect/unstable/ai/McpSchema";
 import * as McpServer from "effect/unstable/ai/McpServer";

--- a/packages/coffee/presentation/mcp/src/server.ts
+++ b/packages/coffee/presentation/mcp/src/server.ts
@@ -1,3 +1,8 @@
+/**
+ * Composes Coffee MCP resources, prompts, and tools into server layers.
+ *
+ * @module
+ */
 import * as Layer from "effect/Layer";
 import * as McpServer from "effect/unstable/ai/McpServer";
 import { CoffeeOrderApp } from "@effect-coffee-shop/coffee-core/application/CoffeeOrderApp";


### PR DESCRIPTION
Adds top-of-file module TSDoc across prioritized production Coffee, backend, infra, presentation, and persistence modules. Expands package documentation with README coverage for all workspace packages, an FAQ-led Coffee actions README, and cross-links between package docs and key source files. Simplifies backend env string normalization with effect/String while formatting affected files. Validation: pre-push affected quality checks passed.