### PR TITLE
refactor(coffee): leverage effect runtime modules

### DIFF
--- a/packages/coffee/assistant/src/application/model.ts
+++ b/packages/coffee/assistant/src/application/model.ts
@@ -5,6 +5,7 @@
  */
 import * as Context from "effect/Context";
 import * as Effect from "effect/Effect";
+import * as JsonSchema from "effect/JsonSchema";
 import * as Option from "effect/Option";
 import * as Schema from "effect/Schema";
 import * as Str from "effect/String";
@@ -43,19 +44,7 @@ export interface AssistantToolDefinition {
   readonly parameters: AssistantToolParameters;
 }
 
-export type AssistantToolParameters = Readonly<{
-  properties: Readonly<
-    Record<
-      string,
-      Readonly<{
-        description?: string;
-        type: string;
-      }>
-    >
-  >;
-  required: readonly string[];
-  type: "object";
-}>;
+export type AssistantToolParameters = JsonSchema.JsonSchema;
 
 export interface AssistantModelRequest {
   readonly conversation: readonly AssistantConversationMessage[];

--- a/packages/coffee/assistant/src/external/providers/config.ts
+++ b/packages/coffee/assistant/src/external/providers/config.ts
@@ -3,11 +3,13 @@
  *
  * @module
  */
+import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Match from "effect/Match";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
 import * as Schema from "effect/Schema";
+import * as ScopedCache from "effect/ScopedCache";
 import { AssistantModelRunner, type AssistantModelRunnerService } from "../../application/model.ts";
 import { type OllamaConfig, makeOllamaRunner } from "./ollama-runtime.ts";
 import {
@@ -130,7 +132,18 @@ export function createAssistantModelRunner(config: AssistantAiConfig): Assistant
 export function createAssistantModelRunnerLayer(
   config: AssistantAiConfig,
 ): Layer.Layer<AssistantModelRunner> {
-  return Layer.succeed(AssistantModelRunner)(createAssistantModelRunner(config));
+  return Layer.effect(
+    AssistantModelRunner,
+    Effect.gen(function* () {
+      const runnerCache = yield* ScopedCache.make({
+        capacity: 1,
+        lookup: (_model: string) => Effect.succeed(createAssistantModelRunner(config)),
+        timeToLive: "1 hour",
+      });
+
+      return yield* ScopedCache.get(runnerCache, getAssistantModelLabel(config));
+    }),
+  );
 }
 
 function getOllamaConfig(input: {

--- a/packages/coffee/assistant/src/presentation/http/chunks.ts
+++ b/packages/coffee/assistant/src/presentation/http/chunks.ts
@@ -4,6 +4,9 @@
  * @module
  */
 import { EventType, type StreamChunk } from "@tanstack/ai";
+import * as Effect from "effect/Effect";
+import * as Queue from "effect/Queue";
+import * as Stream from "effect/Stream";
 
 export interface AssistantChunkQueue<TChunk> {
   readonly stream: AsyncIterable<TChunk>;
@@ -17,43 +20,10 @@ export type AssistantStreamChunk = StreamChunk;
 export function createAssistantChunkQueue<TChunk>(
   signal?: AbortSignal,
 ): AssistantChunkQueue<TChunk> {
-  const items: TChunk[] = [];
-  let failed: unknown;
-  let isClosed = false;
-  let pendingReject: ((error: unknown) => void) | undefined;
-  let pendingResolve: ((result: IteratorResult<TChunk>) => void) | undefined;
-
-  const settlePending = (result: IteratorResult<TChunk>) => {
-    pendingReject = undefined;
-    pendingResolve?.(result);
-    pendingResolve = undefined;
-  };
-
-  const fail = (error: unknown) => {
-    failed = error;
-    isClosed = true;
-    pendingResolve = undefined;
-    pendingReject?.(error);
-    pendingReject = undefined;
-  };
-
-  const close = () => {
-    isClosed = true;
-    settlePending({ value: undefined, done: true });
-  };
-
-  const push = (chunk: TChunk) => {
-    if (isClosed) {
-      return;
-    }
-
-    if (pendingResolve) {
-      settlePending({ value: chunk, done: false });
-      return;
-    }
-
-    items.push(chunk);
-  };
+  const queue = Effect.runSync(Queue.unbounded<TChunk, unknown>());
+  const close = () => void Effect.runSync(Queue.end(queue));
+  const fail = (error: unknown) => void Effect.runSync(Queue.fail(queue, error));
+  const push = (chunk: TChunk) => void Effect.runSync(Queue.offer(queue, chunk));
 
   signal?.addEventListener("abort", close, { once: true });
 
@@ -61,39 +31,7 @@ export function createAssistantChunkQueue<TChunk>(
     close,
     fail,
     push,
-    stream: {
-      async *[Symbol.asyncIterator]() {
-        while (true) {
-          if (items.length > 0) {
-            const next = items.shift();
-
-            if (next !== undefined) {
-              yield next;
-              continue;
-            }
-          }
-
-          if (failed !== undefined) {
-            throw failed;
-          }
-
-          if (isClosed) {
-            return;
-          }
-
-          const next = await new Promise<IteratorResult<TChunk>>((resolve, reject) => {
-            pendingResolve = resolve;
-            pendingReject = reject;
-          });
-
-          if (next.done) {
-            return;
-          }
-
-          yield next.value;
-        }
-      },
-    },
+    stream: Stream.toAsyncIterable(Stream.fromQueue(queue)),
   };
 }
 

--- a/packages/coffee/assistant/src/presentation/http/handler.ts
+++ b/packages/coffee/assistant/src/presentation/http/handler.ts
@@ -4,9 +4,13 @@
  * @module
  */
 import { toServerSentEventsResponse } from "@tanstack/ai";
+import * as Cause from "effect/Cause";
 import * as Effect from "effect/Effect";
+import * as Exit from "effect/Exit";
+import * as FiberSet from "effect/FiberSet";
 import * as Layer from "effect/Layer";
 import * as Context from "effect/Context";
+import * as Scope from "effect/Scope";
 import {
   HostObservabilityLive,
   runHostEffect,
@@ -64,7 +68,6 @@ interface PreparedAssistantRequest {
   readonly body: AssistantRequestBody;
   readonly gatewayEnabled: boolean;
   readonly model: string;
-  readonly modelLayer: NonNullable<AssistantHandlerOptions["modelLayer"]>;
   readonly queue: AssistantChunkQueue<AssistantStreamChunk>;
 }
 
@@ -95,15 +98,34 @@ export async function handleAssistantRequest(
   const abortController = connectAbortSignal(request.signal);
   const queue = createAssistantChunkQueue<AssistantStreamChunk>(abortController.signal);
 
-  void streamAssistantResponse({
-    actor: options.actor,
-    appLayer: options.appLayer,
-    body,
-    gatewayEnabled: options.gatewayEnabled ?? false,
-    model: options.model,
-    modelLayer: options.modelLayer,
-    queue,
-  }).catch((error) => queue.fail(error));
+  const assistantScope = Scope.makeUnsafe("parallel");
+  const runAssistant = Effect.runSync(
+    FiberSet.makeRuntimePromise<never, void, unknown>().pipe(
+      Effect.provideService(Scope.Scope, assistantScope),
+    ),
+  );
+  const closeAssistantScope = () => {
+    void Effect.runPromise(Scope.close(assistantScope, Exit.void));
+  };
+  abortController.signal.addEventListener("abort", closeAssistantScope, { once: true });
+
+  void runAssistant(
+    streamAssistantResponse({
+      actor: options.actor,
+      appLayer: options.appLayer,
+      body,
+      gatewayEnabled: options.gatewayEnabled ?? false,
+      model: options.model,
+      queue,
+    }).pipe(
+      Effect.provide(options.modelLayer),
+      Effect.provide(HostObservabilityLive),
+      Effect.matchCauseEffect({
+        onFailure: (cause) => Effect.sync(() => queue.fail(Cause.squash(cause))),
+        onSuccess: () => Effect.void,
+      }),
+    ),
+  ).finally(closeAssistantScope);
 
   return toServerSentEventsResponse(queue.stream, {
     abortController,
@@ -113,40 +135,38 @@ export async function handleAssistantRequest(
   });
 }
 
-async function streamAssistantResponse(input: PreparedAssistantRequest): Promise<void> {
-  const messageId = createAssistantStreamId("msg");
-  const runId = createAssistantStreamId("chat");
-  const runApp = createCoffeeAppRunner(input.appLayer, input.actor);
-  const startedAt = performance.now();
-  let toolCallCount = 0;
-  const emitActivity = (activity: AssistantToolActivity) => {
-    toolCallCount += Number(activity.kind === "tool-call");
+function streamAssistantResponse(input: PreparedAssistantRequest) {
+  return Effect.gen(function* () {
+    const messageId = createAssistantStreamId("msg");
+    const runId = createAssistantStreamId("chat");
+    const runApp = createCoffeeAppRunner(input.appLayer, input.actor);
+    const startedAt = yield* Effect.sync(() => performance.now());
+    let toolCallCount = 0;
+    const emitActivity = (activity: AssistantToolActivity) => {
+      toolCallCount += Number(activity.kind === "tool-call");
 
-    void runHostEffect(
-      logAssistantToolActivity({
-        activity,
-        actor: input.actor,
-        model: input.model,
-        runId,
-      }),
-    );
-    input.queue.push(
-      createAssistantCustomChunk(input.model, getAssistantToolActivityEvent(), activity),
-    );
-  };
+      void runHostEffect(
+        logAssistantToolActivity({
+          activity,
+          actor: input.actor,
+          model: input.model,
+          runId,
+        }),
+      );
+      input.queue.push(
+        createAssistantCustomChunk(input.model, getAssistantToolActivityEvent(), activity),
+      );
+    };
 
-  input.queue.push(createAssistantRunStartedChunk(runId, input.model));
-  void runHostEffect(
-    logAssistantRunStarted({
+    input.queue.push(createAssistantRunStartedChunk(runId, input.model));
+    yield* logAssistantRunStarted({
       actor: input.actor,
       gatewayEnabled: input.gatewayEnabled,
       model: input.model,
       runId,
-    }),
-  );
+    });
 
-  const response = await Effect.runPromise(
-    runAssistantConversation({
+    const response = yield* runAssistantConversation({
       eventId: runId,
       messages: toAssistantConversationMessages(input.body.messages),
       requestMetadata: createAssistantGatewayMetadata(input.actor, runId),
@@ -170,27 +190,23 @@ async function streamAssistantResponse(input: PreparedAssistantRequest): Promise
         assistant_model: input.model,
         assistant_run_id: runId,
       }),
-      Effect.provide(input.modelLayer),
-      Effect.provide(HostObservabilityLive),
-    ),
-  );
+    );
 
-  input.queue.push(createAssistantTextStartChunk(messageId, input.model));
-  input.queue.push(createAssistantTextContentChunk(messageId, input.model, response));
-  input.queue.push(createAssistantTextEndChunk(messageId, input.model));
-  input.queue.push(createAssistantRunFinishedChunk(runId, input.model));
-  input.queue.close();
+    input.queue.push(createAssistantTextStartChunk(messageId, input.model));
+    input.queue.push(createAssistantTextContentChunk(messageId, input.model, response));
+    input.queue.push(createAssistantTextEndChunk(messageId, input.model));
+    input.queue.push(createAssistantRunFinishedChunk(runId, input.model));
+    input.queue.close();
 
-  await runHostEffect(
-    logAssistantRunCompleted({
+    yield* logAssistantRunCompleted({
       actor: input.actor,
       durationMs: performance.now() - startedAt,
       gatewayEnabled: input.gatewayEnabled,
       model: input.model,
       runId,
       toolCallCount,
-    }),
-  );
+    });
+  });
 }
 
 function createCoffeeAppRunner(

--- a/packages/coffee/assistant/src/tools/parameters.ts
+++ b/packages/coffee/assistant/src/tools/parameters.ts
@@ -4,7 +4,6 @@
  * @module
  */
 import {
-  type CoffeeActionJsonSchema,
   cartItemIdActionJsonSchema,
   checkoutCartActionJsonSchema,
   emptyActionJsonSchema,
@@ -19,36 +18,26 @@ import {
   updateCartItemActionJsonSchema,
 } from "@effect-coffee-shop/coffee-actions/json-schema";
 
-function toAssistantToolParameters(schema: CoffeeActionJsonSchema): CoffeeActionJsonSchema {
-  return { ...schema };
-}
+export const emptyToolParameters = emptyActionJsonSchema;
 
-export const emptyToolParameters = toAssistantToolParameters(emptyActionJsonSchema);
+export const orderIdToolParameters = orderIdActionJsonSchema;
 
-export const orderIdToolParameters = toAssistantToolParameters(orderIdActionJsonSchema);
+export const cartItemIdToolParameters = cartItemIdActionJsonSchema;
 
-export const cartItemIdToolParameters = toAssistantToolParameters(cartItemIdActionJsonSchema);
+export const checkoutCartToolParameters = checkoutCartActionJsonSchema;
 
-export const checkoutCartToolParameters = toAssistantToolParameters(checkoutCartActionJsonSchema);
+export const prepareCartCheckoutToolParameters = prepareCartCheckoutActionJsonSchema;
 
-export const prepareCartCheckoutToolParameters = toAssistantToolParameters(
-  prepareCartCheckoutActionJsonSchema,
-);
+export const getCheckoutSessionToolParameters = getCheckoutSessionActionJsonSchema;
 
-export const getCheckoutSessionToolParameters = toAssistantToolParameters(
-  getCheckoutSessionActionJsonSchema,
-);
+export const itemOptionsToolParameters = itemOptionsActionJsonSchema;
 
-export const itemOptionsToolParameters = toAssistantToolParameters(itemOptionsActionJsonSchema);
+export const listOrdersToolParameters = listOrdersActionJsonSchema;
 
-export const listOrdersToolParameters = toAssistantToolParameters(listOrdersActionJsonSchema);
+export const orderItemToolParameters = orderItemActionJsonSchema;
 
-export const orderItemToolParameters = toAssistantToolParameters(orderItemActionJsonSchema);
+export const placeOrderToolParameters = placeOrderActionJsonSchema;
 
-export const placeOrderToolParameters = toAssistantToolParameters(placeOrderActionJsonSchema);
+export const quoteOrderToolParameters = quoteOrderActionJsonSchema;
 
-export const quoteOrderToolParameters = toAssistantToolParameters(quoteOrderActionJsonSchema);
-
-export const updateCartItemToolParameters = toAssistantToolParameters(
-  updateCartItemActionJsonSchema,
-);
+export const updateCartItemToolParameters = updateCartItemActionJsonSchema;

--- a/packages/coffee/assistant/src/tools/parameters.ts
+++ b/packages/coffee/assistant/src/tools/parameters.ts
@@ -20,11 +20,7 @@ import {
 } from "@effect-coffee-shop/coffee-actions/json-schema";
 
 function toAssistantToolParameters(schema: CoffeeActionJsonSchema): CoffeeActionJsonSchema {
-  return {
-    properties: { ...schema.properties },
-    required: [...schema.required],
-    type: schema.type,
-  };
+  return { ...schema };
 }
 
 export const emptyToolParameters = toAssistantToolParameters(emptyActionJsonSchema);

--- a/packages/coffee/core/src/application/contracts.ts
+++ b/packages/coffee/core/src/application/contracts.ts
@@ -31,6 +31,8 @@ import {
   type CoffeeOrderItem,
 } from "../domain/order.ts";
 
+// Keep menu-choice request fields as trimmed strings so use cases can surface
+// domain-specific errors instead of boundary SchemaError failures.
 const BoundaryStringSchema = Schema.Trim;
 const CartItemIdInputSchema = CartItemIdSchema.annotate({
   description: "Cart line id, such as cart-item-0001.",

--- a/packages/coffee/core/src/application/contracts.ts
+++ b/packages/coffee/core/src/application/contracts.ts
@@ -32,15 +32,48 @@ import {
 } from "../domain/order.ts";
 
 const BoundaryStringSchema = Schema.Trim;
+const CartItemIdInputSchema = CartItemIdSchema.annotate({
+  description: "Cart line id, such as cart-item-0001.",
+});
+const CheckoutSessionIdInputSchema = CheckoutSessionIdSchema.annotate({
+  description: "Checkout session id returned by prepare_cart_checkout.",
+});
+const CustomerNameInputSchema = BoundaryStringSchema.annotate({
+  description: "Optional customer display name for system or staff checkout.",
+});
+const DrinkIdInputSchema = BoundaryStringSchema.annotate({
+  description: "Menu drink id such as latte.",
+});
+const MilkInputSchema = BoundaryStringSchema.annotate({
+  description: "Milk choice such as whole, oat, almond, or none.",
+});
+const NotesInputSchema = BoundaryStringSchema.annotate({
+  description: "Optional item note.",
+});
+const OrderStatusInputSchema = BoundaryStringSchema.annotate({
+  description: "Optional order status filter such as pending, brewing, ready, or picked-up.",
+});
+const QuantityInputFieldSchema = QuantityInputSchema.annotate({
+  description: "Positive line quantity.",
+});
+const ShotCountInputFieldSchema = ShotCountInputSchema.annotate({
+  description: "Number of espresso shots.",
+});
+const SizeInputSchema = BoundaryStringSchema.annotate({
+  description: "Drink size such as small, medium, or large.",
+});
+const TemperatureInputSchema = BoundaryStringSchema.annotate({
+  description: "Drink temperature such as hot or iced.",
+});
 
 export const OrderItemInputSchema = Schema.Struct({
-  drinkId: BoundaryStringSchema,
-  size: BoundaryStringSchema,
-  milk: Schema.optionalKey(BoundaryStringSchema),
-  temperature: Schema.optionalKey(BoundaryStringSchema),
-  shots: Schema.optionalKey(ShotCountInputSchema),
-  notes: Schema.optionalKey(BoundaryStringSchema),
-  quantity: Schema.optionalKey(QuantityInputSchema),
+  drinkId: DrinkIdInputSchema,
+  size: SizeInputSchema,
+  milk: Schema.optionalKey(MilkInputSchema),
+  temperature: Schema.optionalKey(TemperatureInputSchema),
+  shots: Schema.optionalKey(ShotCountInputFieldSchema),
+  notes: Schema.optionalKey(NotesInputSchema),
+  quantity: Schema.optionalKey(QuantityInputFieldSchema),
 }).annotate({ identifier: "OrderItemInput" });
 export type OrderItemInput = typeof OrderItemInputSchema.Type;
 
@@ -50,7 +83,7 @@ export const OrderItemsInputSchema = Schema.NonEmptyArray(OrderItemInputSchema).
 export type OrderItemsInput = typeof OrderItemsInputSchema.Type;
 
 export const PlaceOrderRequestSchema = Schema.Struct({
-  customerName: Schema.optionalKey(BoundaryStringSchema),
+  customerName: Schema.optionalKey(CustomerNameInputSchema),
   items: OrderItemsInputSchema,
 }).annotate({ identifier: "PlaceOrderRequest" });
 export type PlaceOrderRequest = typeof PlaceOrderRequestSchema.Type;
@@ -61,40 +94,40 @@ export const QuoteOrderRequestSchema = Schema.Struct({
 export type QuoteOrderRequest = typeof QuoteOrderRequestSchema.Type;
 
 export const ItemOptionsRequestSchema = Schema.Struct({
-  drinkId: BoundaryStringSchema,
+  drinkId: DrinkIdInputSchema,
 }).annotate({ identifier: "ItemOptionsRequest" });
 export type ItemOptionsRequest = typeof ItemOptionsRequestSchema.Type;
 
 export const UpdateCartItemRequestSchema = Schema.Struct({
-  cartItemId: CartItemIdSchema,
-  drinkId: Schema.optionalKey(BoundaryStringSchema),
-  size: Schema.optionalKey(BoundaryStringSchema),
-  milk: Schema.optionalKey(BoundaryStringSchema),
-  temperature: Schema.optionalKey(BoundaryStringSchema),
-  shots: Schema.optionalKey(ShotCountInputSchema),
-  notes: Schema.optionalKey(BoundaryStringSchema),
-  quantity: Schema.optionalKey(QuantityInputSchema),
+  cartItemId: CartItemIdInputSchema,
+  drinkId: Schema.optionalKey(DrinkIdInputSchema),
+  size: Schema.optionalKey(SizeInputSchema),
+  milk: Schema.optionalKey(MilkInputSchema),
+  temperature: Schema.optionalKey(TemperatureInputSchema),
+  shots: Schema.optionalKey(ShotCountInputFieldSchema),
+  notes: Schema.optionalKey(NotesInputSchema),
+  quantity: Schema.optionalKey(QuantityInputFieldSchema),
 }).annotate({ identifier: "UpdateCartItemRequest" });
 export type UpdateCartItemRequest = typeof UpdateCartItemRequestSchema.Type;
 
 export const CartItemIdRequestSchema = Schema.Struct({
-  cartItemId: CartItemIdSchema,
+  cartItemId: CartItemIdInputSchema,
 }).annotate({ identifier: "CartItemIdRequest" });
 export type CartItemIdRequest = typeof CartItemIdRequestSchema.Type;
 
 export const CheckoutCartRequestSchema = Schema.Struct({
-  checkoutSessionId: CheckoutSessionIdSchema,
-  customerName: Schema.optionalKey(BoundaryStringSchema),
+  checkoutSessionId: CheckoutSessionIdInputSchema,
+  customerName: Schema.optionalKey(CustomerNameInputSchema),
 }).annotate({ identifier: "CheckoutCartRequest" });
 export type CheckoutCartRequest = typeof CheckoutCartRequestSchema.Type;
 
 export const CheckoutSessionIdRequestSchema = Schema.Struct({
-  checkoutSessionId: CheckoutSessionIdSchema,
+  checkoutSessionId: CheckoutSessionIdInputSchema,
 }).annotate({ identifier: "CheckoutSessionIdRequest" });
 export type CheckoutSessionIdRequest = typeof CheckoutSessionIdRequestSchema.Type;
 
 export const ListOrdersRequestSchema = Schema.Struct({
-  status: Schema.optionalKey(BoundaryStringSchema),
+  status: Schema.optionalKey(OrderStatusInputSchema),
 }).annotate({ identifier: "ListOrdersRequest" });
 export type ListOrdersRequest = typeof ListOrdersRequestSchema.Type;
 

--- a/packages/coffee/core/src/application/use-cases/cart.ts
+++ b/packages/coffee/core/src/application/use-cases/cart.ts
@@ -21,7 +21,7 @@ import type {
   OrderItemInput,
   UpdateCartItemRequest,
 } from "../contracts.ts";
-import { OrderItemsInputSchema } from "../contracts.ts";
+import { CartItemQuoteSchema, OrderItemsInputSchema } from "../contracts.ts";
 import { InternalAppError, internalAppErrorFromPersistence } from "../errors.ts";
 import { CartItemIdGenerator } from "../ports/CartItemIdGenerator.ts";
 import { CartRepository } from "../ports/CartRepository.ts";
@@ -29,7 +29,12 @@ import { CheckoutSessionRepository } from "../ports/CheckoutSessionRepository.ts
 import { MenuRepository } from "../ports/MenuRepository.ts";
 import { OrderIdGenerator } from "../ports/OrderIdGenerator.ts";
 import { OrderRepository } from "../ports/OrderRepository.ts";
-import { invalidOrderInput, resolveOrderItem, toOrderItemInput } from "./orderItems.ts";
+import {
+  invalidOrderInput,
+  resolveOrderItem,
+  resolveOrderItems,
+  toOrderItemInput,
+} from "./orderItems.ts";
 import { placeOrder } from "./placeOrder.ts";
 
 const decodeOrderItemsInput = Schema.decodeUnknownEffect(OrderItemsInputSchema);
@@ -64,23 +69,24 @@ const toSnapshot = Effect.fnUntraced(function* (
   DrinkNotFoundError | InvalidOrderInputError | InternalAppError,
   MenuRepository
 > {
-  const items = yield* Effect.forEach(
-    cart.items,
-    (cartItem) =>
-      resolveOrderItem(toOrderItemInput(cartItem)).pipe(
-        Effect.map((item) => ({
-          cartItemId: cartItem.id,
-          item,
-        })),
-      ),
-    { concurrency: 1 },
-  );
+  const resolvedItems = yield* resolveOrderItems(cart.items.map(toOrderItemInput));
+  const items = cart.items.map((cartItem, index) => ({
+    cartItemId: cartItem.id,
+    item: resolvedItems[index],
+  }));
 
-  return {
-    ownerUserId: cart.ownerUserId,
+  return yield* Schema.decodeUnknownEffect(Schema.Array(Schema.toType(CartItemQuoteSchema)))(
     items,
-    totalPrice: sumMoney(items.map((cartItem) => cartItem.item.lineTotal)),
-  };
+  ).pipe(
+    Effect.catchTag("SchemaError", () =>
+      Effect.fail(invalidOrderInput("cart items could not be resolved")),
+    ),
+    Effect.map((decodedItems) => ({
+      ownerUserId: cart.ownerUserId,
+      items: decodedItems,
+      totalPrice: sumMoney(decodedItems.map((cartItem) => cartItem.item.lineTotal)),
+    })),
+  );
 });
 
 const normalizeCartItem = Effect.fnUntraced(function* (

--- a/packages/coffee/core/src/application/use-cases/orderItems.ts
+++ b/packages/coffee/core/src/application/use-cases/orderItems.ts
@@ -5,6 +5,8 @@
  */
 import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
+import * as Request from "effect/Request";
+import * as RequestResolver from "effect/RequestResolver";
 import * as Schema from "effect/Schema";
 import {
   DrinkNotFoundError,
@@ -52,6 +54,15 @@ const decodeTemperature = Schema.decodeUnknownEffect(TemperatureSchema);
 const decodeResolvedItems = Schema.decodeUnknownEffect(
   Schema.NonEmptyArray(Schema.toType(CoffeeOrderItemSchema)),
 );
+type OrderItemResolutionError = DrinkNotFoundError | InvalidOrderInputError | InternalAppError;
+
+class ResolveOrderItemRequest extends Request.TaggedClass("ResolveOrderItemRequest")<
+  {
+    readonly input: OrderItemInput;
+  },
+  CoffeeOrderItem,
+  OrderItemResolutionError
+> {}
 
 const trimmedOption = (value: string | undefined): Option.Option<string> =>
   Option.fromUndefinedOr(value).pipe(
@@ -208,6 +219,24 @@ export const resolveOrderItem = Effect.fnUntraced(function* (
   };
 });
 
+export const resolveOrderItems = Effect.fnUntraced(function* (
+  items: readonly OrderItemInput[],
+): Effect.fn.Return<readonly CoffeeOrderItem[], OrderItemResolutionError, MenuRepository> {
+  const menuRepository = yield* MenuRepository;
+  const resolver = yield* RequestResolver.fromEffect(
+    (entry: Request.Entry<ResolveOrderItemRequest>) =>
+      resolveOrderItem(entry.request.input).pipe(
+        Effect.provideService(MenuRepository, menuRepository),
+      ),
+  ).pipe(RequestResolver.withCache({ capacity: 128 }));
+
+  return yield* Effect.forEach(
+    items,
+    (input) => Effect.request(new ResolveOrderItemRequest({ input }), resolver),
+    { concurrency: "unbounded" },
+  );
+});
+
 export const resolveOrderQuote = Effect.fnUntraced(function* (
   items: readonly OrderItemInput[],
 ): Effect.fn.Return<
@@ -222,7 +251,7 @@ export const resolveOrderQuote = Effect.fnUntraced(function* (
     ),
   );
 
-  const resolvedItemArray = yield* Effect.forEach(items, resolveOrderItem, { concurrency: 1 });
+  const resolvedItemArray = yield* resolveOrderItems(items);
   const resolvedItems = yield* decodeResolvedItems(resolvedItemArray).pipe(
     Effect.catchTag("SchemaError", () =>
       Effect.fail(invalidOrderInput("items must include at least one drink")),

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
@@ -4,8 +4,9 @@
  * @module
  */
 import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 import type { Cart } from "@effect-coffee-shop/coffee-core/domain/cart";
 import { CartRepository } from "@effect-coffee-shop/coffee-core/application/ports/CartRepository";
 
@@ -16,23 +17,19 @@ const emptyCart = (ownerUserId: string): Cart => ({
 
 export const InMemoryCartRepositoryLive = Layer.effect(
   CartRepository,
-  Effect.sync(() => {
-    const carts = new Map<string, Cart>();
+  Effect.gen(function* () {
+    const carts = yield* Ref.make(HashMap.empty<string, Cart>());
 
     return CartRepository.of({
-      getByOwnerUserId: (ownerUserId) =>
-        Effect.succeed(Option.fromUndefinedOr(carts.get(ownerUserId))),
-      save: (cart) =>
-        Effect.sync(() => {
-          carts.set(cart.ownerUserId, cart);
-          return cart;
-        }),
+      getByOwnerUserId: (ownerUserId) => Ref.get(carts).pipe(Effect.map(HashMap.get(ownerUserId))),
+      save: (cart) => Ref.update(carts, HashMap.set(cart.ownerUserId, cart)).pipe(Effect.as(cart)),
       clear: (ownerUserId) =>
-        Effect.sync(() => {
-          const cart = emptyCart(ownerUserId);
-          carts.delete(ownerUserId);
-          return cart;
-        }),
+        Ref.update(carts, HashMap.remove(ownerUserId)).pipe(
+          Effect.map(() => {
+            const cart = emptyCart(ownerUserId);
+            return cart;
+          }),
+        ),
     });
   }),
 );

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCartRepository.ts
@@ -10,7 +10,9 @@ import * as Ref from "effect/Ref";
 import type { Cart } from "@effect-coffee-shop/coffee-core/domain/cart";
 import { CartRepository } from "@effect-coffee-shop/coffee-core/application/ports/CartRepository";
 
-const emptyCart = (ownerUserId: string): Cart => ({
+type CartOwnerUserId = Cart["ownerUserId"];
+
+const emptyCart = (ownerUserId: CartOwnerUserId): Cart => ({
   ownerUserId,
   items: [],
 });
@@ -18,7 +20,7 @@ const emptyCart = (ownerUserId: string): Cart => ({
 export const InMemoryCartRepositoryLive = Layer.effect(
   CartRepository,
   Effect.gen(function* () {
-    const carts = yield* Ref.make(HashMap.empty<string, Cart>());
+    const carts = yield* Ref.make(HashMap.empty<CartOwnerUserId, Cart>());
 
     return CartRepository.of({
       getByOwnerUserId: (ownerUserId) => Ref.get(carts).pipe(Effect.map(HashMap.get(ownerUserId))),

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryCheckoutSessionRepository.ts
@@ -5,40 +5,51 @@
  */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
+import * as Ref from "effect/Ref";
 import type {
   CheckoutSession,
   CheckoutSessionId,
 } from "@effect-coffee-shop/coffee-core/domain/checkout-session";
 import { CheckoutSessionRepository } from "@effect-coffee-shop/coffee-core/application/ports/CheckoutSessionRepository";
 
-export const InMemoryCheckoutSessionRepositoryLive = Layer.sync(CheckoutSessionRepository, () => {
-  const sessions = new Map<CheckoutSessionId, CheckoutSession>();
+export const InMemoryCheckoutSessionRepositoryLive = Layer.effect(
+  CheckoutSessionRepository,
+  Effect.gen(function* () {
+    const sessions = yield* Ref.make(HashMap.empty<CheckoutSessionId, CheckoutSession>());
 
-  const currentSessionForOwner = (ownerUserId: string) =>
-    Array.from(sessions.values())
-      .filter((session) => session.ownerUserId === ownerUserId)
-      .sort(
-        (left, right) =>
-          DateTime.toEpochMillis(right.updatedAt) - DateTime.toEpochMillis(left.updatedAt),
-      )[0];
+    const currentSessionForOwner =
+      (currentSessions: HashMap.HashMap<CheckoutSessionId, CheckoutSession>) =>
+      (ownerUserId: string) =>
+        Array.from(HashMap.values(currentSessions))
+          .filter((session) => session.ownerUserId === ownerUserId)
+          .sort(
+            (left, right) =>
+              DateTime.toEpochMillis(right.updatedAt) - DateTime.toEpochMillis(left.updatedAt),
+          )[0];
 
-  return CheckoutSessionRepository.of({
-    getById: (id) => Effect.succeed(Option.fromUndefinedOr(sessions.get(id))),
-    getCurrentByOwnerUserId: (ownerUserId) =>
-      Effect.succeed(Option.fromUndefinedOr(currentSessionForOwner(ownerUserId))),
-    save: (session) =>
-      Effect.sync(() => {
-        sessions.set(session.id, session);
-        return session;
-      }),
-    clearCurrentByOwnerUserId: (ownerUserId) =>
-      Effect.sync(() => {
-        const current = currentSessionForOwner(ownerUserId);
-        if (current !== undefined) {
-          sessions.delete(current.id);
-        }
-      }),
-  });
-});
+    return CheckoutSessionRepository.of({
+      getById: (id) => Ref.get(sessions).pipe(Effect.map(HashMap.get(id))),
+      getCurrentByOwnerUserId: (ownerUserId) =>
+        Ref.get(sessions).pipe(
+          Effect.map((currentSessions) =>
+            Option.fromUndefinedOr(currentSessionForOwner(currentSessions)(ownerUserId)),
+          ),
+        ),
+      save: (session) =>
+        Ref.update(sessions, HashMap.set(session.id, session)).pipe(Effect.as(session)),
+      clearCurrentByOwnerUserId: (ownerUserId) =>
+        Ref.update(sessions, (currentSessions) =>
+          Option.match(
+            Option.fromUndefinedOr(currentSessionForOwner(currentSessions)(ownerUserId)),
+            {
+              onNone: () => currentSessions,
+              onSome: (current) => HashMap.remove(currentSessions, current.id),
+            },
+          ),
+        ),
+    });
+  }),
+);

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryMenuRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryMenuRepository.ts
@@ -3,14 +3,26 @@
  *
  * @module
  */
+import * as Cache from "effect/Cache";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Option from "effect/Option";
 import { menuItems } from "@effect-coffee-shop/coffee-core/domain/menu";
 import { MenuRepository } from "@effect-coffee-shop/coffee-core/application/ports/MenuRepository";
 
-export const InMemoryMenuRepositoryLive = Layer.succeed(MenuRepository)({
-  list: Effect.succeed(menuItems),
-  findById: (drinkId) =>
-    Effect.succeed(Option.fromUndefinedOr(menuItems.find((item) => item.id === drinkId))),
-});
+export const InMemoryMenuRepositoryLive = Layer.effect(
+  MenuRepository,
+  Effect.gen(function* () {
+    const menuItemCache = yield* Cache.make({
+      capacity: menuItems.length,
+      lookup: (drinkId: string) =>
+        Effect.succeed(Option.fromUndefinedOr(menuItems.find((item) => item.id === drinkId))),
+      timeToLive: "1 hour",
+    });
+
+    return MenuRepository.of({
+      list: Effect.succeed(menuItems),
+      findById: (drinkId) => Cache.get(menuItemCache, drinkId),
+    });
+  }),
+);

--- a/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderRepository.ts
+++ b/packages/coffee/external/in-memory/src/in-memory/InMemoryOrderRepository.ts
@@ -5,35 +5,38 @@
  */
 import * as DateTime from "effect/DateTime";
 import * as Effect from "effect/Effect";
+import * as HashMap from "effect/HashMap";
 import * as Layer from "effect/Layer";
-import * as Option from "effect/Option";
-import type { CoffeeOrder, ListOrdersFilters } from "@effect-coffee-shop/coffee-core/domain/order";
+import * as Ref from "effect/Ref";
+import type {
+  CoffeeOrder,
+  ListOrdersFilters,
+  OrderId,
+} from "@effect-coffee-shop/coffee-core/domain/order";
 import { OrderRepository } from "@effect-coffee-shop/coffee-core/application/ports/OrderRepository";
 
 export const InMemoryOrderRepositoryLive = Layer.effect(
   OrderRepository,
-  Effect.sync(() => {
-    const orders = new Map<string, CoffeeOrder>();
+  Effect.gen(function* () {
+    const orders = yield* Ref.make(HashMap.empty<OrderId, CoffeeOrder>());
 
     return OrderRepository.of({
-      save: (order) =>
-        Effect.sync(() => {
-          orders.set(order.id, order);
-          return order;
-        }),
-      getById: (orderId) => Effect.succeed(Option.fromUndefinedOr(orders.get(orderId))),
+      save: (order) => Ref.update(orders, HashMap.set(order.id, order)).pipe(Effect.as(order)),
+      getById: (orderId) => Ref.get(orders).pipe(Effect.map(HashMap.get(orderId))),
       list: (filters: ListOrdersFilters = {}) =>
-        Effect.succeed(
-          Array.from(orders.values())
-            .filter(
-              (order) =>
-                filters.ownerUserId === undefined || order.ownerUserId === filters.ownerUserId,
-            )
-            .filter((order) => filters.status === undefined || order.status === filters.status)
-            .sort(
-              (left, right) =>
-                DateTime.toEpochMillis(left.createdAt) - DateTime.toEpochMillis(right.createdAt),
-            ),
+        Ref.get(orders).pipe(
+          Effect.map((currentOrders) =>
+            Array.from(HashMap.values(currentOrders))
+              .filter(
+                (order) =>
+                  filters.ownerUserId === undefined || order.ownerUserId === filters.ownerUserId,
+              )
+              .filter((order) => filters.status === undefined || order.status === filters.status)
+              .sort(
+                (left, right) =>
+                  DateTime.toEpochMillis(left.createdAt) - DateTime.toEpochMillis(right.createdAt),
+              ),
+          ),
         ),
     });
   }),

--- a/packages/coffee/presentation/actions/src/json-schema.ts
+++ b/packages/coffee/presentation/actions/src/json-schema.ts
@@ -1,117 +1,51 @@
 /**
- * Converts Coffee action schemas into JSON Schema metadata for tools.
+ * Derives Coffee action JSON Schema metadata from boundary schemas.
  *
  * @module
  */
-export type CoffeeActionJsonSchema = Readonly<{
-  properties: Readonly<
-    Record<
-      string,
-      Readonly<{
-        description?: string;
-        type: string;
-      }>
-    >
-  >;
-  required: readonly string[];
-  type: "object";
-}>;
+import * as JsonSchema from "effect/JsonSchema";
+import * as Match from "effect/Match";
+import * as Schema from "effect/Schema";
+import {
+  CartItemIdRequestSchema,
+  CheckoutCartRequestSchema,
+  ItemOptionsRequestSchema,
+  ListOrdersRequestSchema,
+  OrderItemInputSchema,
+  PlaceOrderRequestSchema,
+  QuoteOrderRequestSchema,
+  UpdateCartItemRequestSchema,
+} from "@effect-coffee-shop/coffee-core/application/contracts";
+import { OrderIdActionInputSchema } from "./schemas.ts";
 
-type CoffeeActionJsonSchemaProperty = CoffeeActionJsonSchema["properties"][string];
+export type CoffeeActionJsonSchema = JsonSchema.JsonSchema;
 
-const property = (
-  description: string,
-  type: CoffeeActionJsonSchemaProperty["type"],
-): CoffeeActionJsonSchemaProperty => ({
-  description,
-  type,
-});
+const EmptyActionInputSchema = Schema.Struct({});
 
-const actionJsonSchema = (
-  properties: CoffeeActionJsonSchema["properties"],
-  required: readonly string[] = [],
-): CoffeeActionJsonSchema => ({
-  properties,
-  required,
-  type: "object",
-});
+function actionJsonSchema(schema: Schema.Top): CoffeeActionJsonSchema {
+  const document = JsonSchema.resolveTopLevel$ref(
+    Schema.toJsonSchemaDocument(schema, { generateDescriptions: true }),
+  );
+  const definitions = document.definitions;
 
-const cartItemIdProperty = property("Cart line id, such as cart-item-0001.", "string");
-const drinkIdProperty = property("Menu drink id such as latte.", "string");
-const milkProperty = property("Milk choice such as whole, oat, almond, or none.", "string");
-const notesProperty = property("Optional item note.", "string");
-const quantityProperty = property("Positive line quantity.", "integer");
-const shotsProperty = property("Number of espresso shots.", "integer");
-const sizeProperty = property("Drink size such as small, medium, or large.", "string");
-const temperatureProperty = property("Drink temperature such as hot or iced.", "string");
+  return Match.value(Object.keys(definitions).length).pipe(
+    Match.when(0, () => document.schema),
+    Match.orElse(() => ({
+      ...document.schema,
+      $defs: definitions,
+    })),
+  );
+}
 
-const orderItemProperties = {
-  drinkId: drinkIdProperty,
-  milk: milkProperty,
-  notes: notesProperty,
-  quantity: quantityProperty,
-  shots: shotsProperty,
-  size: sizeProperty,
-  temperature: temperatureProperty,
-};
-
-export const emptyActionJsonSchema = actionJsonSchema({});
+export const emptyActionJsonSchema = actionJsonSchema(EmptyActionInputSchema);
 export const prepareCartCheckoutActionJsonSchema = emptyActionJsonSchema;
 export const getCheckoutSessionActionJsonSchema = emptyActionJsonSchema;
-
-export const orderIdActionJsonSchema = actionJsonSchema(
-  {
-    orderId: property("Coffee shop ticket id, such as order-0001.", "string"),
-  },
-  ["orderId"],
-);
-
-export const itemOptionsActionJsonSchema = actionJsonSchema({ drinkId: drinkIdProperty }, [
-  "drinkId",
-]);
-
-export const listOrdersActionJsonSchema = actionJsonSchema({
-  status: property(
-    "Optional order status filter such as pending, brewing, ready, or picked-up.",
-    "string",
-  ),
-});
-
-export const placeOrderActionJsonSchema = actionJsonSchema(
-  {
-    items: property(
-      "Order line items. Each item should include drinkId, size, and optional milk, temperature, shots, notes, and quantity.",
-      "array",
-    ),
-  },
-  ["items"],
-);
-
-export const quoteOrderActionJsonSchema = placeOrderActionJsonSchema;
-
-export const orderItemActionJsonSchema = actionJsonSchema(orderItemProperties, ["drinkId", "size"]);
-
-export const updateCartItemActionJsonSchema = actionJsonSchema(
-  {
-    cartItemId: cartItemIdProperty,
-    drinkId: property("Optional replacement menu drink id.", "string"),
-    milk: property("Optional replacement milk choice.", "string"),
-    notes: property("Optional replacement item note.", "string"),
-    quantity: property("Optional positive replacement line quantity.", "integer"),
-    shots: property("Optional replacement espresso shot count.", "integer"),
-    size: property("Optional replacement drink size.", "string"),
-    temperature: property("Optional replacement drink temperature.", "string"),
-  },
-  ["cartItemId"],
-);
-
-export const cartItemIdActionJsonSchema = actionJsonSchema(
-  {
-    cartItemId: cartItemIdProperty,
-  },
-  ["cartItemId"],
-);
-
-export const checkoutCartActionJsonSchema = actionJsonSchema({
-  customerName: property("Optional customer display name for system/staff checkout.", "string"),
-});
+export const orderIdActionJsonSchema = actionJsonSchema(OrderIdActionInputSchema);
+export const itemOptionsActionJsonSchema = actionJsonSchema(ItemOptionsRequestSchema);
+export const listOrdersActionJsonSchema = actionJsonSchema(ListOrdersRequestSchema);
+export const placeOrderActionJsonSchema = actionJsonSchema(PlaceOrderRequestSchema);
+export const quoteOrderActionJsonSchema = actionJsonSchema(QuoteOrderRequestSchema);
+export const orderItemActionJsonSchema = actionJsonSchema(OrderItemInputSchema);
+export const updateCartItemActionJsonSchema = actionJsonSchema(UpdateCartItemRequestSchema);
+export const cartItemIdActionJsonSchema = actionJsonSchema(CartItemIdRequestSchema);
+export const checkoutCartActionJsonSchema = actionJsonSchema(CheckoutCartRequestSchema);

--- a/packages/coffee/presentation/actions/src/schemas.ts
+++ b/packages/coffee/presentation/actions/src/schemas.ts
@@ -40,7 +40,9 @@ export const AppErrorSchema = Schema.Union([
 export const EmptyActionInputSchema = Schema.Struct({});
 
 export const OrderIdActionInputSchema = Schema.Struct({
-  orderId: OrderIdSchema,
+  orderId: OrderIdSchema.annotate({
+    description: "Coffee shop ticket id, such as order-0001.",
+  }),
 });
 
 export const decodeEmptyActionInput = Schema.decodeUnknownPromise(EmptyActionInputSchema);


### PR DESCRIPTION
- Replaces assistant streaming internals with Effect Queue, Stream, and FiberSet-backed scoped execution.
- Derives action/tool JSON schema metadata from Effect Schema annotations while preserving domain-level validation semantics.
- Adds RequestResolver, Cache, and ScopedCache usage for item, menu, and provider model lookups.
- Moves in-memory repositories to Ref<HashMap> state.

DiffsHub: https://diffshub.com/kevinmichaelchen/effect-coffee-shop/pull/75