### PR TITLE
refactor: make Coffee boundaries Effect-native

### DIFF
--- a/apps/backend/src/platforms/aws/env.test.ts
+++ b/apps/backend/src/platforms/aws/env.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests AWS Lambda runtime configuration decoding.
+ *
+ * @module
+ */
+import * as Option from "effect/Option";
+import * as Redacted from "effect/Redacted";
+import { describe, expect, it } from "vitest";
+import { readAwsRuntime, type AwsLambdaEnv } from "./env.ts";
+
+describe("aws runtime config", () => {
+  it("normalizes optional secrets, assistant config, and staff ids", () => {
+    const runtime = readAwsRuntime({
+      BETTER_AUTH_SECRET: " secret-123 ",
+      CLOUDFLARE_ACCOUNT_ID: " account-123 ",
+      CLOUDFLARE_API_TOKEN: " token-123 ",
+      COFFEE_ASSISTANT_MODEL: " @cf/example/model ",
+      COFFEE_ASSISTANT_PROVIDER: " workers-ai-rest ",
+      COFFEE_STAFF_USER_IDS: " staff-a, staff-b , , staff-a ",
+    } satisfies AwsLambdaEnv);
+
+    const assistantAi = Option.getOrUndefined(runtime.config.assistantAi);
+
+    expect(Option.map(runtime.config.betterAuthSecret, Redacted.value)).toEqual(
+      Option.some("secret-123"),
+    );
+    expect([...runtime.config.staffUserIds]).toEqual(["staff-a", "staff-b"]);
+    expect(assistantAi?.kind).toBe("workers-ai-rest");
+
+    if (assistantAi?.kind !== "workers-ai-rest") {
+      return;
+    }
+
+    expect(assistantAi.accountId).toBe("account-123");
+    expect(Redacted.value(assistantAi.apiKey)).toBe("token-123");
+    expect(assistantAi.model).toBe("@cf/example/model");
+  });
+
+  it("treats missing or blank optional values as absent", () => {
+    const runtime = readAwsRuntime({
+      BETTER_AUTH_SECRET: " ",
+      CLOUDFLARE_ACCOUNT_ID: "",
+      CLOUDFLARE_API_TOKEN: "   ",
+      COFFEE_ASSISTANT_MODEL: " ",
+      COFFEE_ASSISTANT_PROVIDER: "",
+      COFFEE_STAFF_USER_IDS: " ,  , ",
+      OLLAMA_HOST: " ",
+    } satisfies AwsLambdaEnv);
+
+    expect(Option.isNone(runtime.config.assistantAi)).toBe(true);
+    expect(Option.isNone(runtime.config.betterAuthSecret)).toBe(true);
+    expect([...runtime.config.staffUserIds]).toEqual([]);
+  });
+
+  it("supports explicit Ollama provider configuration", () => {
+    const runtime = readAwsRuntime({
+      COFFEE_ASSISTANT_MODEL: " qwen3-beanline ",
+      COFFEE_ASSISTANT_OLLAMA_URL: " http://localhost:11434 ",
+      COFFEE_ASSISTANT_PROVIDER: " ollama ",
+    } satisfies AwsLambdaEnv);
+
+    expect(Option.getOrUndefined(runtime.config.assistantAi)).toEqual({
+      endpoint: "http://localhost:11434",
+      kind: "ollama",
+      model: "qwen3-beanline",
+    });
+  });
+});

--- a/apps/backend/src/platforms/aws/env.ts
+++ b/apps/backend/src/platforms/aws/env.ts
@@ -16,9 +16,9 @@ import { parseCsvSet, trimOptionalRedactedString } from "../env.ts";
 export { revealOptionalSecret, revealSecret } from "../env.ts";
 
 export const awsEnvNames = {
+  assistantWorkersAiAccountId: "CLOUDFLARE_ACCOUNT_ID",
+  assistantWorkersAiApiToken: "CLOUDFLARE_API_TOKEN",
   betterAuthSecret: "BETTER_AUTH_SECRET",
-  cloudflareAccountId: "CLOUDFLARE_ACCOUNT_ID",
-  cloudflareApiToken: "CLOUDFLARE_API_TOKEN",
   coffeeAssistantModel: "COFFEE_ASSISTANT_MODEL",
   coffeeAssistantOllamaUrl: "COFFEE_ASSISTANT_OLLAMA_URL",
   coffeeAssistantProvider: "COFFEE_ASSISTANT_PROVIDER",
@@ -48,9 +48,9 @@ export interface AwsRuntime {
 }
 
 const awsRuntimeConfig = Config.all({
+  assistantWorkersAiAccountId: Config.option(Config.string("cloudflareAccountId")),
+  assistantWorkersAiApiToken: Config.option(Config.redacted("cloudflareApiToken")),
   betterAuthSecret: Config.option(Config.redacted("betterAuthSecret")),
-  cloudflareAccountId: Config.option(Config.string("cloudflareAccountId")),
-  cloudflareApiToken: Config.option(Config.redacted("cloudflareApiToken")),
   coffeeAssistantModel: Config.option(Config.string("coffeeAssistantModel")),
   coffeeAssistantOllamaUrl: Config.option(Config.string("coffeeAssistantOllamaUrl")),
   coffeeAssistantProvider: Config.option(Config.string("coffeeAssistantProvider")),
@@ -59,9 +59,9 @@ const awsRuntimeConfig = Config.all({
 });
 
 interface AwsRuntimeConfig {
+  readonly assistantWorkersAiAccountId: Option.Option<string>;
+  readonly assistantWorkersAiApiToken: Option.Option<Redacted.Redacted<string>>;
   readonly betterAuthSecret: Option.Option<Redacted.Redacted<string>>;
-  readonly cloudflareAccountId: Option.Option<string>;
-  readonly cloudflareApiToken: Option.Option<Redacted.Redacted<string>>;
   readonly coffeeAssistantModel: Option.Option<string>;
   readonly coffeeAssistantOllamaUrl: Option.Option<string>;
   readonly coffeeAssistantProvider: Option.Option<string>;
@@ -77,8 +77,8 @@ const optionalRedactedValue = (
 ): string | undefined => Option.getOrUndefined(Option.map(value, Redacted.value));
 
 const toAssistantEnv = (env: AwsRuntimeConfig): Record<string, string | undefined> => ({
-  [awsEnvNames.cloudflareAccountId]: optionalStringValue(env.cloudflareAccountId),
-  [awsEnvNames.cloudflareApiToken]: optionalRedactedValue(env.cloudflareApiToken),
+  [awsEnvNames.assistantWorkersAiAccountId]: optionalStringValue(env.assistantWorkersAiAccountId),
+  [awsEnvNames.assistantWorkersAiApiToken]: optionalRedactedValue(env.assistantWorkersAiApiToken),
   [awsEnvNames.coffeeAssistantModel]: optionalStringValue(env.coffeeAssistantModel),
   [awsEnvNames.coffeeAssistantOllamaUrl]: optionalStringValue(env.coffeeAssistantOllamaUrl),
   [awsEnvNames.coffeeAssistantProvider]: optionalStringValue(env.coffeeAssistantProvider),

--- a/apps/backend/src/platforms/aws/env.ts
+++ b/apps/backend/src/platforms/aws/env.ts
@@ -3,14 +3,16 @@
  *
  * @module
  */
+import * as Config from "effect/Config";
+import * as ConfigProvider from "effect/ConfigProvider";
+import * as Effect from "effect/Effect";
 import * as Option from "effect/Option";
 import * as Redacted from "effect/Redacted";
-import * as Schema from "effect/Schema";
 import {
   getAssistantAiConfigFromEnv,
   type AssistantAiConfig,
 } from "@effect-coffee-shop/coffee-assistant/providers";
-import { optionalTrimmedRedactedString, parseCsvSet } from "../env.ts";
+import { parseCsvSet, trimOptionalRedactedString } from "../env.ts";
 export { revealOptionalSecret, revealSecret } from "../env.ts";
 
 export const awsEnvNames = {
@@ -25,19 +27,17 @@ export const awsEnvNames = {
   ollamaHost: "OLLAMA_HOST",
 } as const;
 
-const AwsLambdaEnvSchema = Schema.Struct({
-  BETTER_AUTH_SECRET: Schema.optionalKey(Schema.String),
-  CLOUDFLARE_ACCOUNT_ID: Schema.optionalKey(Schema.String),
-  CLOUDFLARE_API_TOKEN: Schema.optionalKey(Schema.String),
-  COFFEE_ASSISTANT_MODEL: Schema.optionalKey(Schema.String),
-  COFFEE_ASSISTANT_OLLAMA_URL: Schema.optionalKey(Schema.String),
-  COFFEE_ASSISTANT_PROVIDER: Schema.optionalKey(Schema.String),
-  COFFEE_POSTGRES_URL: Schema.optionalKey(Schema.String),
-  COFFEE_STAFF_USER_IDS: Schema.optionalKey(Schema.String),
-  OLLAMA_HOST: Schema.optionalKey(Schema.String),
-});
-
-export type AwsLambdaEnv = Schema.Schema.Type<typeof AwsLambdaEnvSchema>;
+export interface AwsLambdaEnv {
+  readonly BETTER_AUTH_SECRET?: string;
+  readonly CLOUDFLARE_ACCOUNT_ID?: string;
+  readonly CLOUDFLARE_API_TOKEN?: string;
+  readonly COFFEE_ASSISTANT_MODEL?: string;
+  readonly COFFEE_ASSISTANT_OLLAMA_URL?: string;
+  readonly COFFEE_ASSISTANT_PROVIDER?: string;
+  readonly COFFEE_POSTGRES_URL?: string;
+  readonly COFFEE_STAFF_USER_IDS?: string;
+  readonly OLLAMA_HOST?: string;
+}
 
 export interface AwsRuntime {
   readonly config: {
@@ -47,30 +47,59 @@ export interface AwsRuntime {
   };
 }
 
-const decodeAwsLambdaEnv = Schema.decodeUnknownSync(AwsLambdaEnvSchema);
+const awsRuntimeConfig = Config.all({
+  betterAuthSecret: Config.option(Config.redacted("betterAuthSecret")),
+  cloudflareAccountId: Config.option(Config.string("cloudflareAccountId")),
+  cloudflareApiToken: Config.option(Config.redacted("cloudflareApiToken")),
+  coffeeAssistantModel: Config.option(Config.string("coffeeAssistantModel")),
+  coffeeAssistantOllamaUrl: Config.option(Config.string("coffeeAssistantOllamaUrl")),
+  coffeeAssistantProvider: Config.option(Config.string("coffeeAssistantProvider")),
+  coffeeStaffUserIds: Config.string("coffeeStaffUserIds").pipe(Config.withDefault("")),
+  ollamaHost: Config.option(Config.string("ollamaHost")),
+});
 
-const toAssistantEnv = (env: AwsLambdaEnv): Record<string, string | undefined> => ({
-  [awsEnvNames.cloudflareAccountId]: env.CLOUDFLARE_ACCOUNT_ID,
-  [awsEnvNames.cloudflareApiToken]: env.CLOUDFLARE_API_TOKEN,
-  [awsEnvNames.coffeeAssistantModel]: env.COFFEE_ASSISTANT_MODEL,
-  [awsEnvNames.coffeeAssistantOllamaUrl]: env.COFFEE_ASSISTANT_OLLAMA_URL,
-  [awsEnvNames.coffeeAssistantProvider]: env.COFFEE_ASSISTANT_PROVIDER,
-  [awsEnvNames.ollamaHost]: env.OLLAMA_HOST,
+interface AwsRuntimeConfig {
+  readonly betterAuthSecret: Option.Option<Redacted.Redacted<string>>;
+  readonly cloudflareAccountId: Option.Option<string>;
+  readonly cloudflareApiToken: Option.Option<Redacted.Redacted<string>>;
+  readonly coffeeAssistantModel: Option.Option<string>;
+  readonly coffeeAssistantOllamaUrl: Option.Option<string>;
+  readonly coffeeAssistantProvider: Option.Option<string>;
+  readonly coffeeStaffUserIds: string;
+  readonly ollamaHost: Option.Option<string>;
+}
+
+const optionalStringValue = (value: Option.Option<string>): string | undefined =>
+  Option.getOrUndefined(value);
+
+const optionalRedactedValue = (
+  value: Option.Option<Redacted.Redacted<string>>,
+): string | undefined => Option.getOrUndefined(Option.map(value, Redacted.value));
+
+const toAssistantEnv = (env: AwsRuntimeConfig): Record<string, string | undefined> => ({
+  [awsEnvNames.cloudflareAccountId]: optionalStringValue(env.cloudflareAccountId),
+  [awsEnvNames.cloudflareApiToken]: optionalRedactedValue(env.cloudflareApiToken),
+  [awsEnvNames.coffeeAssistantModel]: optionalStringValue(env.coffeeAssistantModel),
+  [awsEnvNames.coffeeAssistantOllamaUrl]: optionalStringValue(env.coffeeAssistantOllamaUrl),
+  [awsEnvNames.coffeeAssistantProvider]: optionalStringValue(env.coffeeAssistantProvider),
+  [awsEnvNames.ollamaHost]: optionalStringValue(env.ollamaHost),
 });
 
 export const readAwsRuntime = (env: unknown): AwsRuntime => {
-  const decodedEnv = decodeAwsLambdaEnv(env);
-  const assistantEnv = toAssistantEnv(decodedEnv);
+  const decodedConfig = Effect.runSync(
+    awsRuntimeConfig.parse(ConfigProvider.fromUnknown(env).pipe(ConfigProvider.constantCase)),
+  );
+  const assistantEnv = toAssistantEnv(decodedConfig);
   const assistantAi = getAssistantAiConfigFromEnv(assistantEnv);
 
   return {
     config: {
       assistantAi: Option.fromNullishOr(assistantAi),
-      betterAuthSecret: optionalTrimmedRedactedString(
-        decodedEnv.BETTER_AUTH_SECRET,
+      betterAuthSecret: trimOptionalRedactedString(
+        decodedConfig.betterAuthSecret,
         awsEnvNames.betterAuthSecret,
       ),
-      staffUserIds: parseCsvSet(decodedEnv.COFFEE_STAFF_USER_IDS),
+      staffUserIds: parseCsvSet(decodedConfig.coffeeStaffUserIds),
     },
   };
 };

--- a/apps/backend/src/platforms/aws/lambda.ts
+++ b/apps/backend/src/platforms/aws/lambda.ts
@@ -28,9 +28,9 @@ const configuredBetterAuthSecret = Config.redacted(awsEnvNames.betterAuthSecret)
 );
 
 const runtimeEnvConfig = Config.all({
+  assistantWorkersAiAccountId: optionalVariableConfig(awsEnvNames.assistantWorkersAiAccountId),
+  assistantWorkersAiApiToken: optionalSecretConfig(awsEnvNames.assistantWorkersAiApiToken),
   betterAuthSecret: optionalSecretConfig(awsEnvNames.betterAuthSecret),
-  cloudflareAccountId: optionalVariableConfig(awsEnvNames.cloudflareAccountId),
-  cloudflareApiToken: optionalSecretConfig(awsEnvNames.cloudflareApiToken),
   coffeeAssistantModel: optionalVariableConfig(awsEnvNames.coffeeAssistantModel),
   coffeeAssistantOllamaUrl: optionalVariableConfig(awsEnvNames.coffeeAssistantOllamaUrl),
   coffeeAssistantProvider: optionalVariableConfig(awsEnvNames.coffeeAssistantProvider),
@@ -41,8 +41,8 @@ const runtimeEnvConfig = Config.all({
   Config.map(
     (env): AwsLambdaEnv => ({
       BETTER_AUTH_SECRET: Redacted.value(env.betterAuthSecret),
-      CLOUDFLARE_ACCOUNT_ID: env.cloudflareAccountId,
-      CLOUDFLARE_API_TOKEN: Redacted.value(env.cloudflareApiToken),
+      CLOUDFLARE_ACCOUNT_ID: env.assistantWorkersAiAccountId,
+      CLOUDFLARE_API_TOKEN: Redacted.value(env.assistantWorkersAiApiToken),
       COFFEE_ASSISTANT_MODEL: env.coffeeAssistantModel,
       COFFEE_ASSISTANT_OLLAMA_URL: env.coffeeAssistantOllamaUrl,
       COFFEE_ASSISTANT_PROVIDER: env.coffeeAssistantProvider,
@@ -65,13 +65,13 @@ export default class CoffeeApi extends AWS.Lambda.Function<CoffeeApi>()(
 
     return {
       env: {
+        [awsEnvNames.assistantWorkersAiAccountId]: yield* optionalVariableConfig(
+          awsEnvNames.assistantWorkersAiAccountId,
+        ).pipe(Effect.orDie),
+        [awsEnvNames.assistantWorkersAiApiToken]: yield* optionalSecretConfig(
+          awsEnvNames.assistantWorkersAiApiToken,
+        ).pipe(Effect.orDie),
         [awsEnvNames.betterAuthSecret]: betterAuthSecret,
-        [awsEnvNames.cloudflareAccountId]: yield* optionalVariableConfig(
-          awsEnvNames.cloudflareAccountId,
-        ).pipe(Effect.orDie),
-        [awsEnvNames.cloudflareApiToken]: yield* optionalSecretConfig(
-          awsEnvNames.cloudflareApiToken,
-        ).pipe(Effect.orDie),
         [awsEnvNames.coffeeAssistantModel]: yield* optionalVariableConfig(
           awsEnvNames.coffeeAssistantModel,
         ).pipe(Effect.orDie),

--- a/apps/ui/src/shared/lib/http.ts
+++ b/apps/ui/src/shared/lib/http.ts
@@ -1,3 +1,4 @@
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 class HttpRequestError extends Schema.TaggedErrorClass<HttpRequestError>()("HttpRequestError", {
@@ -13,94 +14,162 @@ class HttpResponseDecodeError extends Schema.TaggedErrorClass<HttpResponseDecode
   },
 ) {}
 
-interface JsonRequestInput<
-  SuccessSchema extends Schema.Decoder<unknown>,
-  ErrorSchema extends Schema.Decoder<unknown> | undefined = undefined,
-> {
+interface JsonRequestInputBase<SuccessSchema extends Schema.Decoder<unknown>> {
   readonly errorMessage?: string;
-  readonly errorSchema?: ErrorSchema;
   readonly init?: RequestInit;
   readonly path: string;
-  readonly readErrorMessage?: ErrorSchema extends Schema.Decoder<unknown>
-    ? (error: ErrorSchema["Type"]) => string
-    : undefined;
   readonly schema: SuccessSchema;
 }
 
-export async function requestJson<
+interface JsonRequestInputWithError<
   SuccessSchema extends Schema.Decoder<unknown>,
-  ErrorSchema extends Schema.Decoder<unknown> | undefined = undefined,
->(input: JsonRequestInput<SuccessSchema, ErrorSchema>): Promise<SuccessSchema["Type"]> {
-  const response = await fetch(input.path, input.init);
-
-  if (!response.ok) {
-    return rejectRequestError(
-      response,
-      input.errorMessage,
-      input.errorSchema,
-      input.readErrorMessage,
-    );
-  }
-
-  const decodedResponse = await readResponseJson(response, input.schema)
-    .then((value) => ({ success: true as const, value }))
-    .catch(() => ({ success: false as const }));
-
-  if (!decodedResponse.success) {
-    return Promise.reject(
-      new HttpResponseDecodeError({
-        message: `Unexpected response body from ${input.path}.`,
-        status: response.status,
-      }),
-    );
-  }
-
-  return decodedResponse.value;
+  ErrorSchema extends Schema.Decoder<unknown>,
+> extends JsonRequestInputBase<SuccessSchema> {
+  readonly errorSchema: ErrorSchema;
+  readonly readErrorMessage: (error: ErrorSchema["Type"]) => string;
 }
 
-async function rejectRequestError(
-  response: Response,
-  fallbackMessage: string | undefined,
-  errorSchema: Schema.Decoder<unknown> | undefined,
-  readErrorMessage: ((error: unknown) => string) | undefined,
-): Promise<never> {
-  const fallback = fallbackMessage ?? `${response.status} ${response.statusText}`;
+interface JsonRequestInputWithoutError<
+  SuccessSchema extends Schema.Decoder<unknown>,
+> extends JsonRequestInputBase<SuccessSchema> {
+  readonly errorSchema?: undefined;
+  readonly readErrorMessage?: undefined;
+}
 
-  if (errorSchema === undefined || readErrorMessage === undefined) {
-    return Promise.reject(
-      new HttpRequestError({
-        message: fallback,
-        status: response.status,
-      }),
-    );
-  }
+type JsonRequestInput<
+  SuccessSchema extends Schema.Decoder<unknown>,
+  ErrorSchema extends Schema.Decoder<unknown>,
+> =
+  | JsonRequestInputWithError<SuccessSchema, ErrorSchema>
+  | JsonRequestInputWithoutError<SuccessSchema>;
 
-  const rawBody = await response.text();
-  const message = await decodeJsonText(rawBody, errorSchema)
-    .then(readErrorMessage)
-    .catch(() => fallback);
+export function requestJson<SuccessSchema extends Schema.Decoder<unknown>>(
+  input: JsonRequestInputWithoutError<SuccessSchema>,
+): Promise<SuccessSchema["Type"]>;
+export function requestJson<
+  SuccessSchema extends Schema.Decoder<unknown>,
+  ErrorSchema extends Schema.Decoder<unknown>,
+>(input: JsonRequestInputWithError<SuccessSchema, ErrorSchema>): Promise<SuccessSchema["Type"]>;
+export async function requestJson<
+  SuccessSchema extends Schema.Decoder<unknown>,
+  ErrorSchema extends Schema.Decoder<unknown>,
+>(input: JsonRequestInput<SuccessSchema, ErrorSchema>): Promise<SuccessSchema["Type"]> {
+  return Effect.runPromise(requestJsonEffect(input));
+}
 
-  return Promise.reject(
-    new HttpRequestError({
-      message,
-      status: response.status,
-    }),
+function requestJsonEffect<
+  SuccessSchema extends Schema.Decoder<unknown>,
+  ErrorSchema extends Schema.Decoder<unknown>,
+>(
+  input: JsonRequestInput<SuccessSchema, ErrorSchema>,
+): Effect.Effect<SuccessSchema["Type"], HttpRequestError | HttpResponseDecodeError> {
+  return fetchResponse(input).pipe(
+    Effect.flatMap(
+      (
+        response,
+      ): Effect.Effect<SuccessSchema["Type"], HttpRequestError | HttpResponseDecodeError> =>
+        response.ok
+          ? readResponseJson(response, input.path, input.schema)
+          : rejectRequestError(response, input),
+    ),
   );
 }
 
-async function readResponseJson<SuccessSchema extends Schema.Decoder<unknown>>(
-  response: Response,
-  schema: SuccessSchema,
-): Promise<SuccessSchema["Type"]> {
-  const rawBody = await response.text();
-  return decodeJsonText(rawBody, schema);
+function fetchResponse(input: {
+  readonly errorMessage?: string;
+  readonly init?: RequestInit;
+  readonly path: string;
+}): Effect.Effect<Response, HttpRequestError> {
+  return Effect.tryPromise({
+    try: async () => fetch(input.path, input.init),
+    catch: () =>
+      new HttpRequestError({
+        message: input.errorMessage ?? `Unable to request ${input.path}.`,
+        status: 0,
+      }),
+  });
 }
 
-async function decodeJsonText<SchemaType extends Schema.Decoder<unknown>>(
+function rejectRequestError<
+  SuccessSchema extends Schema.Decoder<unknown>,
+  ErrorSchema extends Schema.Decoder<unknown>,
+>(
+  response: Response,
+  input: JsonRequestInput<SuccessSchema, ErrorSchema>,
+): Effect.Effect<never, HttpRequestError> {
+  const fallbackMessage = input.errorMessage ?? `${response.status} ${response.statusText}`;
+  const errorSchema = input.errorSchema;
+  const readErrorMessage = input.readErrorMessage;
+
+  if (errorSchema === undefined || readErrorMessage === undefined) {
+    return Effect.fail(
+      new HttpRequestError({
+        message: fallbackMessage,
+        status: response.status,
+      }),
+    );
+  }
+
+  return readResponseText(response, input.path).pipe(
+    Effect.matchEffect({
+      onFailure: () => Effect.succeed(fallbackMessage),
+      onSuccess: (rawBody) =>
+        decodeJsonText(rawBody, response.status, input.path, errorSchema).pipe(
+          Effect.matchEffect({
+            onFailure: () => Effect.succeed(fallbackMessage),
+            onSuccess: (error) => Effect.succeed(readErrorMessage(error)),
+          }),
+        ),
+    }),
+    Effect.flatMap((message) =>
+      Effect.fail(
+        new HttpRequestError({
+          message,
+          status: response.status,
+        }),
+      ),
+    ),
+  );
+}
+
+function readResponseJson<SuccessSchema extends Schema.Decoder<unknown>>(
+  response: Response,
+  path: string,
+  schema: SuccessSchema,
+): Effect.Effect<SuccessSchema["Type"], HttpResponseDecodeError> {
+  return readResponseText(response, path).pipe(
+    Effect.flatMap((rawBody) => decodeJsonText(rawBody, response.status, path, schema)),
+  );
+}
+
+function readResponseText(
+  response: Response,
+  path: string,
+): Effect.Effect<string, HttpResponseDecodeError> {
+  return Effect.tryPromise({
+    try: async () => response.text(),
+    catch: () =>
+      new HttpResponseDecodeError({
+        message: `Unable to read response body from ${path}.`,
+        status: response.status,
+      }),
+  });
+}
+
+function decodeJsonText<SchemaType extends Schema.Decoder<unknown>>(
   rawBody: string,
+  status: number,
+  path: string,
   schema: SchemaType,
-): Promise<SchemaType["Type"]> {
-  return Schema.decodeUnknownPromise(schema)(
-    Schema.decodeUnknownSync(Schema.UnknownFromJsonString)(rawBody),
+): Effect.Effect<SchemaType["Type"], HttpResponseDecodeError> {
+  return Schema.decodeUnknownEffect(Schema.UnknownFromJsonString)(rawBody).pipe(
+    Effect.flatMap(Schema.decodeUnknownEffect(schema)),
+    Effect.mapError(
+      () =>
+        new HttpResponseDecodeError({
+          message: `Unexpected response body from ${path}.`,
+          status,
+        }),
+    ),
   );
 }

--- a/packages/backend-host/src/observability.ts
+++ b/packages/backend-host/src/observability.ts
@@ -2,6 +2,7 @@ import * as Config from "effect/Config";
 import * as Effect from "effect/Effect";
 import * as Layer from "effect/Layer";
 import * as Logger from "effect/Logger";
+import * as ManagedRuntime from "effect/ManagedRuntime";
 import * as Metric from "effect/Metric";
 import * as Option from "effect/Option";
 import { FetchHttpClient } from "effect/unstable/http";
@@ -63,6 +64,8 @@ export const HostObservabilityLive = Layer.mergeAll(
   OtlpObservabilityLive,
 );
 
+const HostObservabilityRuntime = ManagedRuntime.make(HostObservabilityLive);
+
 const requestTotal = Metric.counter("fetch_host_requests_total", {
   description: "Total Fetch host requests handled by route, method, and outcome.",
   incremental: true,
@@ -81,7 +84,7 @@ const requestDurationMs = Metric.histogram("fetch_host_request_duration_ms", {
 type MetricAttributes = Readonly<Record<string, string>>;
 
 export function runHostEffect<A, E>(effect: Effect.Effect<A, E>): Promise<A> {
-  return Effect.runPromise(effect.pipe(Effect.provide(HostObservabilityLive)));
+  return HostObservabilityRuntime.runPromise(effect);
 }
 
 export function recordFetchHostRequestCompleted(input: {

--- a/packages/coffee/assistant/src/presentation/http/handler.ts
+++ b/packages/coffee/assistant/src/presentation/http/handler.ts
@@ -216,9 +216,11 @@ function createCoffeeAppRunner(
   const liveLayer = CoffeeOrderApp.layer.pipe(Layer.provide(appLayer));
   const services = emptyWebHandlerServices().pipe(Context.add(CurrentActor, actor));
 
-  return async (effect) =>
-    Effect.runPromiseWith(services)(
-      effect.pipe(Effect.provide(liveLayer), Effect.provide(HostObservabilityLive)),
+  return (effect) =>
+    effect.pipe(
+      Effect.provide(liveLayer),
+      Effect.provide(HostObservabilityLive),
+      Effect.provide(services),
     );
 }
 

--- a/packages/coffee/assistant/src/presentation/http/messages.test.ts
+++ b/packages/coffee/assistant/src/presentation/http/messages.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests assistant request body parsing at the HTTP boundary.
+ *
+ * @module
+ */
+import { jsonString } from "@effect-coffee-shop/backend-host/json";
+import { describe, expect, it } from "vitest";
+import { parseAssistantRequestBody } from "./messages.ts";
+
+const makeJsonRequest = (body: unknown): Request =>
+  new Request("http://example.com/assistant", {
+    body: jsonString(body),
+    headers: {
+      "content-type": "application/json",
+    },
+    method: "POST",
+  });
+
+describe("assistant request body parsing", () => {
+  it("accepts model-style assistant messages", async () => {
+    const body = await parseAssistantRequestBody(
+      makeJsonRequest({
+        messages: [
+          {
+            content: "List the menu briefly.",
+            role: "user",
+          },
+        ],
+      }),
+    );
+
+    expect(body).toEqual({
+      messages: [
+        {
+          content: "List the menu briefly.",
+          role: "user",
+        },
+      ],
+    });
+  });
+
+  it("accepts browser UI messages", async () => {
+    const body = await parseAssistantRequestBody(
+      makeJsonRequest({
+        messages: [
+          {
+            id: "message-1",
+            parts: [{ content: "List the menu briefly.", type: "text" }],
+            role: "user",
+          },
+        ],
+      }),
+    );
+
+    expect(body).toEqual({
+      messages: [
+        {
+          id: "message-1",
+          parts: [{ content: "List the menu briefly.", type: "text" }],
+          role: "user",
+        },
+      ],
+    });
+  });
+
+  it("returns null for invalid JSON", async () => {
+    const body = await parseAssistantRequestBody(
+      new Request("http://example.com/assistant", {
+        body: "{",
+        headers: {
+          "content-type": "application/json",
+        },
+        method: "POST",
+      }),
+    );
+
+    expect(body).toBeNull();
+  });
+
+  it("returns null for bodies outside the assistant request schema", async () => {
+    const body = await parseAssistantRequestBody(
+      makeJsonRequest({
+        messages: [
+          {
+            content: "List the menu briefly.",
+            role: "admin",
+          },
+        ],
+      }),
+    );
+
+    expect(body).toBeNull();
+  });
+});

--- a/packages/coffee/assistant/src/presentation/http/messages.ts
+++ b/packages/coffee/assistant/src/presentation/http/messages.ts
@@ -4,6 +4,7 @@
  * @module
  */
 import type { AssistantConversationMessage } from "../../application/model.ts";
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 
 const AssistantContentTextPartSchema = Schema.Struct({
@@ -36,16 +37,29 @@ export type AssistantRequestBody = typeof AssistantRequestBodySchema.Type;
 type AssistantRequestMessage = (typeof AssistantRequestBodySchema.Type.messages)[number];
 type AssistantUiMessageInput = typeof AssistantUiMessageSchema.Type;
 
-const decodeAssistantRequestBody = Schema.decodeUnknownPromise(AssistantRequestBodySchema);
+const decodeAssistantRequestBody = Schema.decodeUnknownEffect(AssistantRequestBodySchema);
 const isAssistantUiMessage = Schema.is(AssistantUiMessageSchema);
 
 export async function parseAssistantRequestBody(
   request: Request,
 ): Promise<AssistantRequestBody | null> {
-  return request
-    .json()
-    .then(decodeAssistantRequestBody)
-    .catch(() => null);
+  return Effect.runPromise(
+    Effect.tryPromise({
+      try: async () => request.json(),
+      catch: () => null,
+    }).pipe(
+      Effect.matchEffect({
+        onFailure: () => Effect.succeed(null),
+        onSuccess: (body) =>
+          decodeAssistantRequestBody(body).pipe(
+            Effect.matchEffect({
+              onFailure: () => Effect.succeed(null),
+              onSuccess: Effect.succeed,
+            }),
+          ),
+      }),
+    ),
+  );
 }
 
 export function toAssistantConversationMessages(

--- a/packages/coffee/assistant/src/tools/definitions.ts
+++ b/packages/coffee/assistant/src/tools/definitions.ts
@@ -5,7 +5,7 @@
  */
 import { type CoffeeActionName, coffeeActionSpecs } from "@effect-coffee-shop/coffee-actions/specs";
 import {
-  executeCoffeeAction,
+  executeCoffeeActionEffect,
   type CoffeeAppRunner,
 } from "@effect-coffee-shop/coffee-actions/execute";
 import * as Effect from "effect/Effect";
@@ -101,14 +101,10 @@ function createAppTool(input: {
           label: name,
         });
 
-        return yield* Effect.tryPromise({
-          try: () =>
-            executeCoffeeAction({
-              action,
-              payload: toolInput,
-              runApp,
-            }),
-          catch: (error) => error,
+        return yield* executeCoffeeActionEffect({
+          action,
+          payload: toolInput,
+          runApp,
         }).pipe(
           Effect.match({
             onFailure: (error) => {

--- a/packages/coffee/auth/src/agent-auth.test.ts
+++ b/packages/coffee/auth/src/agent-auth.test.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from "@cloudflare/workers-types";
 import type { AgentSession } from "@better-auth/agent-auth";
+import * as Effect from "effect/Effect";
 import * as Schema from "effect/Schema";
 import { Miniflare } from "miniflare";
 import { describe, expect, it } from "vitest";
@@ -12,7 +13,7 @@ import {
 import {
   createCoffeeAgentAppRunner,
   createCoffeeAgentAuthOptions,
-  executeCoffeeAgentCapability,
+  executeCoffeeAgentCapabilityEffect,
 } from "@effect-coffee-shop/coffee-auth/agent/options";
 import { makeCloudflareCoffeeAppLive } from "@effect-coffee-shop/coffee-external-sqlite/cloudflare";
 
@@ -60,15 +61,17 @@ async function placeLatteOrder(db: D1Database, session: AgentSession) {
     appLayer: makeCloudflareCoffeeAppLive(db),
     session,
   });
-  const result = await executeCoffeeAgentCapability({
-    arguments: {
-      items: [{ drinkId: "latte", size: "medium" }],
-    },
-    capability: "place_order",
-    runApp,
-  });
+  const result = await Effect.runPromise(
+    executeCoffeeAgentCapabilityEffect({
+      arguments: {
+        items: [{ drinkId: "latte", size: "medium" }],
+      },
+      capability: "place_order",
+      runApp,
+    }),
+  );
 
-  return Schema.decodeUnknownPromise(CoffeeOrderViewSchema)(result);
+  return Effect.runPromise(Schema.decodeUnknownEffect(CoffeeOrderViewSchema)(result));
 }
 
 async function listOrders(db: D1Database, session: AgentSession): Promise<CoffeeOrdersView> {
@@ -76,13 +79,15 @@ async function listOrders(db: D1Database, session: AgentSession): Promise<Coffee
     appLayer: makeCloudflareCoffeeAppLive(db),
     session,
   });
-  const result = await executeCoffeeAgentCapability({
-    arguments: {},
-    capability: "list_orders",
-    runApp,
-  });
+  const result = await Effect.runPromise(
+    executeCoffeeAgentCapabilityEffect({
+      arguments: {},
+      capability: "list_orders",
+      runApp,
+    }),
+  );
 
-  return Schema.decodeUnknownPromise(CoffeeOrdersViewSchema)(result);
+  return Effect.runPromise(Schema.decodeUnknownEffect(CoffeeOrdersViewSchema)(result));
 }
 
 async function getOrder(
@@ -94,13 +99,15 @@ async function getOrder(
     appLayer: makeCloudflareCoffeeAppLive(db),
     session,
   });
-  const result = await executeCoffeeAgentCapability({
-    arguments: { orderId },
-    capability: "get_order",
-    runApp,
-  });
+  const result = await Effect.runPromise(
+    executeCoffeeAgentCapabilityEffect({
+      arguments: { orderId },
+      capability: "get_order",
+      runApp,
+    }),
+  );
 
-  return Schema.decodeUnknownPromise(CoffeeOrderViewSchema)(result);
+  return Effect.runPromise(Schema.decodeUnknownEffect(CoffeeOrderViewSchema)(result));
 }
 
 describe("coffee agent auth", () => {
@@ -165,14 +172,16 @@ describe("coffee agent auth", () => {
       });
 
       await expect(
-        executeCoffeeAgentCapability({
-          arguments: {},
-          capability: "place_order",
-          runApp: createCoffeeAgentAppRunner({
-            appLayer: makeCloudflareCoffeeAppLive(db),
-            session,
+        Effect.runPromise(
+          executeCoffeeAgentCapabilityEffect({
+            arguments: {},
+            capability: "place_order",
+            runApp: createCoffeeAgentAppRunner({
+              appLayer: makeCloudflareCoffeeAppLive(db),
+              session,
+            }),
           }),
-        }),
+        ),
       ).rejects.toThrowError("Invalid place_order arguments.");
     });
   });

--- a/packages/coffee/auth/src/agent/options.ts
+++ b/packages/coffee/auth/src/agent/options.ts
@@ -26,10 +26,11 @@ import { CoffeeOrderApp } from "@effect-coffee-shop/coffee-core/application/Coff
 import { CurrentActor } from "@effect-coffee-shop/coffee-core/application/CurrentActor";
 
 type CoffeeAppRunner = <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) => Promise<A>;
+type AgentInputDecoder<A> = (value: unknown) => Effect.Effect<A, unknown>;
 
 interface AgentActionInput {
   readonly action: CoffeeActionName;
-  readonly decode: (value: unknown) => Promise<unknown>;
+  readonly decode: AgentInputDecoder<unknown>;
   readonly failureMessage: string;
 }
 
@@ -80,22 +81,23 @@ function toExecutionError(error: unknown): AgentCapabilityExecutionError {
 }
 
 function decodeAgentInput<A>(input: {
-  readonly decode: (value: unknown) => Promise<A>;
+  readonly decode: AgentInputDecoder<A>;
   readonly failureMessage: string;
   readonly value: unknown;
 }): Effect.Effect<A, AgentCapabilityInputError> {
-  return Effect.tryPromise({
-    try: () => input.decode(input.value),
-    catch: () =>
-      new AgentCapabilityInputError({
-        message: input.failureMessage,
-      }),
-  });
+  return input.decode(input.value).pipe(
+    Effect.mapError(
+      () =>
+        new AgentCapabilityInputError({
+          message: input.failureMessage,
+        }),
+    ),
+  );
 }
 
 function runAgentAction<A>(input: {
   readonly action: CoffeeActionName;
-  readonly decode: (value: unknown) => Promise<A>;
+  readonly decode: AgentInputDecoder<A>;
   readonly failureMessage: string;
   readonly arguments: unknown;
   readonly runApp: CoffeeAppRunner;
@@ -123,7 +125,7 @@ function runAgentAction<A>(input: {
 
 const agentActionInput = (
   action: CoffeeActionName,
-  decode: (value: unknown) => Promise<unknown>,
+  decode: AgentInputDecoder<unknown>,
 ): AgentActionInput => ({
   action,
   decode,

--- a/packages/coffee/auth/src/agent/options.ts
+++ b/packages/coffee/auth/src/agent/options.ts
@@ -17,7 +17,7 @@ import {
   decodeQuoteOrderInput,
   decodeUpdateCartItemInput,
 } from "@effect-coffee-shop/coffee-actions/schemas";
-import { executeCoffeeAction } from "@effect-coffee-shop/coffee-actions/execute";
+import { executeCoffeeActionEffect } from "@effect-coffee-shop/coffee-actions/execute";
 import type { CoffeeActionName } from "@effect-coffee-shop/coffee-actions/specs";
 import { emptyWebHandlerServices } from "@effect-coffee-shop/backend-host/request-services";
 import { coffeeAgentCapabilities } from "./capabilities.ts";
@@ -110,15 +110,11 @@ function runAgentAction<A>(input: {
     value: payload,
   }).pipe(
     Effect.flatMap(() =>
-      Effect.tryPromise({
-        try: () =>
-          executeCoffeeAction({
-            action: input.action,
-            payload,
-            runApp: input.runApp,
-          }),
-        catch: toExecutionError,
-      }),
+      executeCoffeeActionEffect({
+        action: input.action,
+        payload,
+        runApp: input.runApp,
+      }).pipe(Effect.mapError(toExecutionError)),
     ),
   );
 }

--- a/packages/coffee/auth/src/agent/options.ts
+++ b/packages/coffee/auth/src/agent/options.ts
@@ -79,47 +79,46 @@ function toExecutionError(error: unknown): AgentCapabilityExecutionError {
   });
 }
 
-async function decodeAgentInput<A>(input: {
+function decodeAgentInput<A>(input: {
   readonly decode: (value: unknown) => Promise<A>;
   readonly failureMessage: string;
   readonly value: unknown;
-}): Promise<A> {
-  const result = await input
-    .decode(input.value)
-    .then((value) => ({ success: true as const, value }))
-    .catch(() => ({ success: false as const }));
-
-  if (!result.success) {
-    return Promise.reject(
+}): Effect.Effect<A, AgentCapabilityInputError> {
+  return Effect.tryPromise({
+    try: () => input.decode(input.value),
+    catch: () =>
       new AgentCapabilityInputError({
         message: input.failureMessage,
       }),
-    );
-  }
-
-  return result.value;
+  });
 }
 
-async function runAgentAction<A>(input: {
+function runAgentAction<A>(input: {
   readonly action: CoffeeActionName;
   readonly decode: (value: unknown) => Promise<A>;
   readonly failureMessage: string;
   readonly arguments: unknown;
   readonly runApp: CoffeeAppRunner;
-}) {
+}): Effect.Effect<unknown, AgentCapabilityExecutionError | AgentCapabilityInputError> {
   const payload = input.arguments ?? {};
 
-  await decodeAgentInput({
+  return decodeAgentInput({
     decode: input.decode,
     failureMessage: input.failureMessage,
     value: payload,
-  });
-
-  return executeCoffeeAction({
-    action: input.action,
-    payload,
-    runApp: input.runApp,
-  }).catch((error) => Promise.reject(toExecutionError(error)));
+  }).pipe(
+    Effect.flatMap(() =>
+      Effect.tryPromise({
+        try: () =>
+          executeCoffeeAction({
+            action: input.action,
+            payload,
+            runApp: input.runApp,
+          }),
+        catch: toExecutionError,
+      }),
+    ),
+  );
 }
 
 const agentActionInput = (
@@ -181,21 +180,31 @@ export async function executeCoffeeAgentCapability(input: {
   readonly arguments: unknown;
   readonly capability: string;
   readonly runApp: CoffeeAppRunner;
-}) {
-  return Option.match(agentActionInputFor(input.capability), {
-    onNone: () =>
-      Promise.reject(
-        new UnsupportedAgentCapabilityError({
-          capability: input.capability,
+}): Promise<unknown> {
+  return Effect.runPromise(
+    Option.match(agentActionInputFor(input.capability), {
+      onNone: (): Effect.Effect<
+        unknown,
+        AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
+      > =>
+        Effect.fail(
+          new UnsupportedAgentCapabilityError({
+            capability: input.capability,
+          }),
+        ),
+      onSome: (
+        actionInput,
+      ): Effect.Effect<
+        unknown,
+        AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
+      > =>
+        runAgentAction({
+          ...actionInput,
+          arguments: input.arguments,
+          runApp: input.runApp,
         }),
-      ),
-    onSome: (actionInput) =>
-      runAgentAction({
-        ...actionInput,
-        arguments: input.arguments,
-        runApp: input.runApp,
-      }),
-  });
+    }),
+  );
 }
 
 export function createCoffeeAgentAuthOptions(input: {

--- a/packages/coffee/auth/src/agent/options.ts
+++ b/packages/coffee/auth/src/agent/options.ts
@@ -17,7 +17,10 @@ import {
   decodeQuoteOrderInput,
   decodeUpdateCartItemInput,
 } from "@effect-coffee-shop/coffee-actions/schemas";
-import { executeCoffeeActionEffect } from "@effect-coffee-shop/coffee-actions/execute";
+import {
+  executeCoffeeActionEffect,
+  type CoffeeAppRunner,
+} from "@effect-coffee-shop/coffee-actions/execute";
 import type { CoffeeActionName } from "@effect-coffee-shop/coffee-actions/specs";
 import { emptyWebHandlerServices } from "@effect-coffee-shop/backend-host/request-services";
 import { coffeeAgentCapabilities } from "./capabilities.ts";
@@ -25,7 +28,6 @@ import { formatToolFailure } from "@effect-coffee-shop/coffee-actions/format";
 import { CoffeeOrderApp } from "@effect-coffee-shop/coffee-core/application/CoffeeOrderApp";
 import { CurrentActor } from "@effect-coffee-shop/coffee-core/application/CurrentActor";
 
-type CoffeeAppRunner = <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) => Promise<A>;
 type AgentInputDecoder<A> = (value: unknown) => Effect.Effect<A, unknown>;
 
 interface AgentActionInput {
@@ -70,8 +72,8 @@ export function createCoffeeAgentAppRunner(input: {
     Context.add(CurrentActor, toAgentActor(input.session)),
   );
 
-  return async <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) =>
-    Effect.runPromiseWith(services)(effect.pipe(Effect.provide(liveLayer)));
+  return <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) =>
+    effect.pipe(Effect.provide(liveLayer), Effect.provide(services));
 }
 
 function toExecutionError(error: unknown): AgentCapabilityExecutionError {
@@ -174,35 +176,36 @@ const agentActionInputFor = (capability: string): Option.Option<AgentActionInput
     Match.orElse(() => Option.none()),
   );
 
-export async function executeCoffeeAgentCapability(input: {
+export function executeCoffeeAgentCapabilityEffect(input: {
   readonly arguments: unknown;
   readonly capability: string;
   readonly runApp: CoffeeAppRunner;
-}): Promise<unknown> {
-  return Effect.runPromise(
-    Option.match(agentActionInputFor(input.capability), {
-      onNone: (): Effect.Effect<
-        unknown,
-        AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
-      > =>
-        Effect.fail(
-          new UnsupportedAgentCapabilityError({
-            capability: input.capability,
-          }),
-        ),
-      onSome: (
-        actionInput,
-      ): Effect.Effect<
-        unknown,
-        AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
-      > =>
-        runAgentAction({
-          ...actionInput,
-          arguments: input.arguments,
-          runApp: input.runApp,
+}): Effect.Effect<
+  unknown,
+  AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
+> {
+  return Option.match(agentActionInputFor(input.capability), {
+    onNone: (): Effect.Effect<
+      unknown,
+      AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
+    > =>
+      Effect.fail(
+        new UnsupportedAgentCapabilityError({
+          capability: input.capability,
         }),
-    }),
-  );
+      ),
+    onSome: (
+      actionInput,
+    ): Effect.Effect<
+      unknown,
+      AgentCapabilityExecutionError | AgentCapabilityInputError | UnsupportedAgentCapabilityError
+    > =>
+      runAgentAction({
+        ...actionInput,
+        arguments: input.arguments,
+        runApp: input.runApp,
+      }),
+  });
 }
 
 export function createCoffeeAgentAuthOptions(input: {
@@ -228,11 +231,13 @@ export function createCoffeeAgentAuthOptions(input: {
         session: agentSession,
       });
 
-      return executeCoffeeAgentCapability({
-        arguments: args,
-        capability,
-        runApp,
-      });
+      return Effect.runPromise(
+        executeCoffeeAgentCapabilityEffect({
+          arguments: args,
+          capability,
+          runApp,
+        }),
+      );
     },
     providerDescription:
       "Coffee ordering capabilities for delegated AI agents acting on behalf of a signed-in customer.",

--- a/packages/coffee/presentation/actions/src/execute.ts
+++ b/packages/coffee/presentation/actions/src/execute.ts
@@ -33,7 +33,9 @@ import {
 } from "./schemas.ts";
 import type { CoffeeActionName } from "./specs.ts";
 
-export type CoffeeAppRunner = <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) => Promise<A>;
+export type CoffeeAppRunner = <A, E>(
+  effect: Effect.Effect<A, E, CoffeeOrderApp>,
+) => Effect.Effect<A, E>;
 type CoffeeOrderAppService = Context.Service.Shape<typeof CoffeeOrderApp>;
 type ActionInputDecoder<A> = (payload: unknown) => Effect.Effect<A, unknown>;
 
@@ -56,20 +58,11 @@ const noCheckoutSessionView: NoCheckoutSessionView = {
 
 const payloadOrEmpty = (payload: unknown): unknown => payload ?? {};
 
-const runAppEffect = <A, E>(
-  input: ActionContext,
-  effect: Effect.Effect<A, E, CoffeeOrderApp>,
-): Effect.Effect<A, unknown> =>
-  Effect.tryPromise({
-    try: () => input.runApp(effect),
-    catch: (error) => error,
-  });
-
 const runEmptyAction =
   <A, E>(runEffect: (app: CoffeeOrderAppService) => Effect.Effect<A, E>): ActionHandler =>
   (input) =>
     decodeEmptyActionInput(payloadOrEmpty(input.payload)).pipe(
-      Effect.flatMap(() => runAppEffect(input, CoffeeOrderApp.use(runEffect))),
+      Effect.flatMap(() => input.runApp(CoffeeOrderApp.use(runEffect))),
     );
 
 const runDecodedAction =
@@ -80,10 +73,7 @@ const runDecodedAction =
   (input) =>
     decode(payloadOrEmpty(input.payload)).pipe(
       Effect.flatMap((payload) =>
-        runAppEffect(
-          input,
-          CoffeeOrderApp.use((app) => runEffect(app, payload)),
-        ),
+        input.runApp(CoffeeOrderApp.use((app) => runEffect(app, payload))),
       ),
     );
 
@@ -149,8 +139,4 @@ export function executeCoffeeActionEffect(
   input: CoffeeActionExecutionInput,
 ): Effect.Effect<unknown, unknown> {
   return actionHandlers[input.action](input);
-}
-
-export async function executeCoffeeAction(input: CoffeeActionExecutionInput): Promise<unknown> {
-  return Effect.runPromise(executeCoffeeActionEffect(input));
 }

--- a/packages/coffee/presentation/actions/src/execute.ts
+++ b/packages/coffee/presentation/actions/src/execute.ts
@@ -42,6 +42,12 @@ interface ActionContext {
   readonly runApp: CoffeeAppRunner;
 }
 
+export interface CoffeeActionExecutionInput {
+  readonly action: CoffeeActionName;
+  readonly payload: unknown;
+  readonly runApp: CoffeeAppRunner;
+}
+
 type ActionHandler = (input: ActionContext) => Effect.Effect<unknown, unknown>;
 
 const noCheckoutSessionView: NoCheckoutSessionView = {
@@ -139,10 +145,12 @@ const actionHandlers = {
   ),
 } satisfies Record<CoffeeActionName, ActionHandler>;
 
-export async function executeCoffeeAction(input: {
-  readonly action: CoffeeActionName;
-  readonly payload: unknown;
-  readonly runApp: CoffeeAppRunner;
-}): Promise<unknown> {
-  return Effect.runPromise(actionHandlers[input.action](input));
+export function executeCoffeeActionEffect(
+  input: CoffeeActionExecutionInput,
+): Effect.Effect<unknown, unknown> {
+  return actionHandlers[input.action](input);
+}
+
+export async function executeCoffeeAction(input: CoffeeActionExecutionInput): Promise<unknown> {
+  return Effect.runPromise(executeCoffeeActionEffect(input));
 }

--- a/packages/coffee/presentation/actions/src/execute.ts
+++ b/packages/coffee/presentation/actions/src/execute.ts
@@ -35,13 +35,14 @@ import type { CoffeeActionName } from "./specs.ts";
 
 export type CoffeeAppRunner = <A, E>(effect: Effect.Effect<A, E, CoffeeOrderApp>) => Promise<A>;
 type CoffeeOrderAppService = Context.Service.Shape<typeof CoffeeOrderApp>;
+type ActionInputDecoder<A> = (payload: unknown) => Effect.Effect<A, unknown>;
 
 interface ActionContext {
   readonly payload: unknown;
   readonly runApp: CoffeeAppRunner;
 }
 
-type ActionHandler = (input: ActionContext) => Promise<unknown>;
+type ActionHandler = (input: ActionContext) => Effect.Effect<unknown, unknown>;
 
 const noCheckoutSessionView: NoCheckoutSessionView = {
   status: "no_checkout_session",
@@ -49,22 +50,36 @@ const noCheckoutSessionView: NoCheckoutSessionView = {
 
 const payloadOrEmpty = (payload: unknown): unknown => payload ?? {};
 
+const runAppEffect = <A, E>(
+  input: ActionContext,
+  effect: Effect.Effect<A, E, CoffeeOrderApp>,
+): Effect.Effect<A, unknown> =>
+  Effect.tryPromise({
+    try: () => input.runApp(effect),
+    catch: (error) => error,
+  });
+
 const runEmptyAction =
   <A, E>(runEffect: (app: CoffeeOrderAppService) => Effect.Effect<A, E>): ActionHandler =>
-  async (input) => {
-    await decodeEmptyActionInput(payloadOrEmpty(input.payload));
-    return input.runApp(CoffeeOrderApp.use(runEffect));
-  };
+  (input) =>
+    decodeEmptyActionInput(payloadOrEmpty(input.payload)).pipe(
+      Effect.flatMap(() => runAppEffect(input, CoffeeOrderApp.use(runEffect))),
+    );
 
 const runDecodedAction =
   <Payload, A, E>(
-    decode: (payload: unknown) => Promise<Payload>,
+    decode: ActionInputDecoder<Payload>,
     runEffect: (app: CoffeeOrderAppService, payload: Payload) => Effect.Effect<A, E>,
   ): ActionHandler =>
-  async (input) => {
-    const payload = await decode(payloadOrEmpty(input.payload));
-    return input.runApp(CoffeeOrderApp.use((app) => runEffect(app, payload)));
-  };
+  (input) =>
+    decode(payloadOrEmpty(input.payload)).pipe(
+      Effect.flatMap((payload) =>
+        runAppEffect(
+          input,
+          CoffeeOrderApp.use((app) => runEffect(app, payload)),
+        ),
+      ),
+    );
 
 const runOrderIdAction = <E>(
   runEffect: (app: CoffeeOrderAppService, orderId: OrderId) => Effect.Effect<CoffeeOrder, E>,
@@ -129,5 +144,5 @@ export async function executeCoffeeAction(input: {
   readonly payload: unknown;
   readonly runApp: CoffeeAppRunner;
 }): Promise<unknown> {
-  return actionHandlers[input.action](input);
+  return Effect.runPromise(actionHandlers[input.action](input));
 }

--- a/packages/coffee/presentation/actions/src/schemas.test.ts
+++ b/packages/coffee/presentation/actions/src/schemas.test.ts
@@ -1,21 +1,24 @@
 import { assert, describe, expect, it } from "vitest";
+import * as Effect from "effect/Effect";
 import { decodePlaceOrderInput, decodeQuoteOrderInput } from "./schemas.ts";
 
 describe("coffee action schemas", () => {
   it("trims order boundary strings before application use cases run", async () => {
-    const input = await decodePlaceOrderInput({
-      customerName: "  Avery  ",
-      items: [
-        {
-          drinkId: " latte ",
-          milk: " oat ",
-          notes: "  extra hot  ",
-          quantity: 2,
-          size: " medium ",
-          temperature: " hot ",
-        },
-      ],
-    });
+    const input = await Effect.runPromise(
+      decodePlaceOrderInput({
+        customerName: "  Avery  ",
+        items: [
+          {
+            drinkId: " latte ",
+            milk: " oat ",
+            notes: "  extra hot  ",
+            quantity: 2,
+            size: " medium ",
+            temperature: " hot ",
+          },
+        ],
+      }),
+    );
 
     assert.strictEqual(input.customerName, "Avery");
     assert.strictEqual(input.items[0].drinkId, "latte");
@@ -27,15 +30,17 @@ describe("coffee action schemas", () => {
 
   it("rejects old single-drink order payloads", async () => {
     await expect(
-      decodePlaceOrderInput({
-        customerName: "Avery",
-        drinkId: "latte",
-        size: "medium",
-      }),
+      Effect.runPromise(
+        decodePlaceOrderInput({
+          customerName: "Avery",
+          drinkId: "latte",
+          size: "medium",
+        }),
+      ),
     ).rejects.toThrow();
   });
 
   it("rejects empty quote item lists at the boundary", async () => {
-    await expect(decodeQuoteOrderInput({ items: [] })).rejects.toThrow();
+    await expect(Effect.runPromise(decodeQuoteOrderInput({ items: [] }))).rejects.toThrow();
   });
 });

--- a/packages/coffee/presentation/actions/src/schemas.ts
+++ b/packages/coffee/presentation/actions/src/schemas.ts
@@ -45,13 +45,13 @@ export const OrderIdActionInputSchema = Schema.Struct({
   }),
 });
 
-export const decodeEmptyActionInput = Schema.decodeUnknownPromise(EmptyActionInputSchema);
-export const decodeOrderIdInput = Schema.decodeUnknownPromise(OrderIdActionInputSchema);
-export const decodeCartItemIdInput = Schema.decodeUnknownPromise(CartItemIdRequestSchema);
-export const decodeCheckoutCartInput = Schema.decodeUnknownPromise(CheckoutCartRequestSchema);
-export const decodeItemOptionsInput = Schema.decodeUnknownPromise(ItemOptionsRequestSchema);
-export const decodeListOrdersInput = Schema.decodeUnknownPromise(ListOrdersRequestSchema);
-export const decodeOrderItemInput = Schema.decodeUnknownPromise(OrderItemInputSchema);
-export const decodePlaceOrderInput = Schema.decodeUnknownPromise(PlaceOrderRequestSchema);
-export const decodeQuoteOrderInput = Schema.decodeUnknownPromise(QuoteOrderRequestSchema);
-export const decodeUpdateCartItemInput = Schema.decodeUnknownPromise(UpdateCartItemRequestSchema);
+export const decodeEmptyActionInput = Schema.decodeUnknownEffect(EmptyActionInputSchema);
+export const decodeOrderIdInput = Schema.decodeUnknownEffect(OrderIdActionInputSchema);
+export const decodeCartItemIdInput = Schema.decodeUnknownEffect(CartItemIdRequestSchema);
+export const decodeCheckoutCartInput = Schema.decodeUnknownEffect(CheckoutCartRequestSchema);
+export const decodeItemOptionsInput = Schema.decodeUnknownEffect(ItemOptionsRequestSchema);
+export const decodeListOrdersInput = Schema.decodeUnknownEffect(ListOrdersRequestSchema);
+export const decodeOrderItemInput = Schema.decodeUnknownEffect(OrderItemInputSchema);
+export const decodePlaceOrderInput = Schema.decodeUnknownEffect(PlaceOrderRequestSchema);
+export const decodeQuoteOrderInput = Schema.decodeUnknownEffect(QuoteOrderRequestSchema);
+export const decodeUpdateCartItemInput = Schema.decodeUnknownEffect(UpdateCartItemRequestSchema);


### PR DESCRIPTION
## Summary
- refactor JSON/request/action boundaries toward Effect-native decoding and execution
- remove dead Promise-first Coffee action adapters in favor of Effect-returning runners
- clarify AWS assistant provider env names and read runtime env through ConfigProvider
- add focused coverage for AWS/env parsing and assistant/action boundary behavior

## Rationale
Codegraph showed the Promise helpers in effect-smol are thin outer-boundary wrappers around Effect APIs: `Schema.decodeUnknownPromise` delegates to `decodeUnknownEffect` via `Effect.runPromise`. This PR keeps Promise conversion at external/framework boundaries and keeps internal Coffee action/auth/assistant flow Effect-native.

## Size
- 14 files changed
- 543 additions / 233 deletions
- net +310 lines

## Verification
- `bun run typecheck:affected`
- `bun run test:affected`
- `bun run lint:affected`
- `bun run fmt:check -- --affected`
- focused package checks for actions, assistant, and auth
- pre-push affected quality checks

Note: PRs #76 and #77 are intentionally left open; this is the aggregate branch for single-PR review.